### PR TITLE
Fix Large Template Validation Error

### DIFF
--- a/scripts/github/validate-changeset.sh
+++ b/scripts/github/validate-changeset.sh
@@ -17,12 +17,40 @@ if ! aws cloudformation describe-stacks --stack-name "$STACK_NAME" &>/dev/null; 
     exit 0
 fi
 
+# Upload template to S3 for large templates
+TEMPLATE_FILE="cdk/cdk.out/$STACK_NAME.template.json"
+TEMPLATE_SIZE=$(wc -c < "$TEMPLATE_FILE")
+
+if [ "$TEMPLATE_SIZE" -gt 51200 ]; then
+    echo "📤 Template is large ($TEMPLATE_SIZE bytes), uploading to S3..."
+    
+    # Get CDK bootstrap bucket
+    CDK_BUCKET=$(aws cloudformation describe-stacks \
+        --stack-name CDKToolkit \
+        --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' \
+        --output text)
+    
+    if [ -z "$CDK_BUCKET" ]; then
+        echo "❌ CDK bootstrap bucket not found. Run 'cdk bootstrap' first."
+        exit 1
+    fi
+    
+    # Upload template
+    TEMPLATE_KEY="changeset-validation/$(basename $TEMPLATE_FILE)"
+    aws s3 cp "$TEMPLATE_FILE" "s3://$CDK_BUCKET/$TEMPLATE_KEY"
+    TEMPLATE_URL="https://s3.amazonaws.com/$CDK_BUCKET/$TEMPLATE_KEY"
+    
+    TEMPLATE_PARAM="--template-url $TEMPLATE_URL"
+else
+    TEMPLATE_PARAM="--template-body file://$TEMPLATE_FILE"
+fi
+
 # Create changeset
 CHANGESET_NAME="github-actions-$(date +%s)"
 aws cloudformation create-change-set \
     --stack-name "$STACK_NAME" \
     --change-set-name "$CHANGESET_NAME" \
-    --template-body file://cdk/cdk.out/$STACK_NAME.template.json \
+    $TEMPLATE_PARAM \
     --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
     --change-set-type UPDATE
 
@@ -49,6 +77,11 @@ if [ "$CHANGES" != "[]" ]; then
         --stack-name "$STACK_NAME" \
         --change-set-name "$CHANGESET_NAME"
     
+    # Clean up S3 template if uploaded
+    if [ -n "$CDK_BUCKET" ] && [ -n "$TEMPLATE_KEY" ]; then
+        aws s3 rm "s3://$CDK_BUCKET/$TEMPLATE_KEY"
+    fi
+    
     echo ""
     echo "💡 To override this check, include '[force-deploy]' in your commit message"
     exit 1
@@ -58,5 +91,10 @@ fi
 aws cloudformation delete-change-set \
     --stack-name "$STACK_NAME" \
     --change-set-name "$CHANGESET_NAME"
+
+# Clean up S3 template if uploaded
+if [ -n "$CDK_BUCKET" ] && [ -n "$TEMPLATE_KEY" ]; then
+    aws s3 rm "s3://$CDK_BUCKET/$TEMPLATE_KEY"
+fi
 
 echo "✅ No breaking changes detected"


### PR DESCRIPTION
# Fix Large Template Validation Error

## Problem
Changeset validation was failing with:
```
Member must have length less than or equal to 51200
```

## Solution
Modified `validate-changeset.sh` to handle large CloudFormation templates by uploading to S3 instead of using inline template body.

## Changes
- Check template size before creating changeset
- Upload large templates to CDK bootstrap S3 bucket
- Use `--template-url` for large templates, `--template-body` for small ones
- Clean up uploaded templates after validation

## Testing
- Large CloudTAK templates now validate successfully
- Small templates continue to work with inline body
- S3 cleanup prevents bucket pollution

Fixes CloudFormation template size limit errors in CI/CD pipeline.
