### PR TITLE
Reorganize Test Workflows and Infrastructure Fixes

### DIFF
--- a/.github/workflows/cloudtak-test.yml
+++ b/.github/workflows/cloudtak-test.yml
@@ -15,6 +15,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  api:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker API Build
+        run: docker buildx build ./api -t cloudtak-api
+
+      - name: Docker API Lint
+        run: docker run cloudtak-api:latest sh -c "npm install --include=dev && npm run lint"
+
   data:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -35,9 +35,14 @@ permissions:
   contents: read
 
 jobs:
+  # Run CloudTAK application tests before building
+  cloudtak-test:
+    uses: ./.github/workflows/cloudtak-test.yml
+
   build-images:
     runs-on: ubuntu-latest
     environment: demo
+    needs: [cloudtak-test]
     outputs:
       cloudtak-tag: ${{ steps.tags.outputs.cloudtak-tag }}
     steps:

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -26,10 +26,6 @@ jobs:
   cdk-test:
     uses: ./.github/workflows/cdk-test.yml
 
-  # Run CloudTAK application tests
-  cloudtak-test:
-    uses: ./.github/workflows/cloudtak-test.yml
-
   # Build Docker images for demo environment
   build-images:
     uses: ./.github/workflows/demo-build.yml
@@ -40,7 +36,7 @@ jobs:
   validate-prod:
     runs-on: ubuntu-latest
     environment: demo
-    needs: [cdk-test, cloudtak-test]
+    needs: [cdk-test]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -32,9 +32,14 @@ permissions:
   contents: read
 
 jobs:
+  # Run CloudTAK application tests before building
+  cloudtak-test:
+    uses: ./.github/workflows/cloudtak-test.yml
+
   build-images:
     runs-on: ubuntu-latest
     environment: production
+    needs: [cloudtak-test]
     outputs:
       cloudtak-tag: ${{ steps.tags.outputs.cloudtak-tag }}
     steps:

--- a/cdk/lib/constructs/batch.ts
+++ b/cdk/lib/constructs/batch.ts
@@ -95,7 +95,7 @@ export class Batch extends Construct {
     const privateSubnets = vpc.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS });
 
     this.computeEnvironment = new batch.CfnComputeEnvironment(this, 'ComputeEnvironment', {
-      computeEnvironmentName: `TAK-${envConfig.stackName}-CloudTAK-compute-env`,
+      computeEnvironmentName: `TAK-${envConfig.stackName}-CloudTAK-compute-env-${cdk.Names.uniqueId(this).slice(-8)}`,
       type: 'MANAGED',
       state: 'ENABLED',
       serviceRole: batchServiceRole.roleArn,
@@ -117,7 +117,7 @@ export class Batch extends Construct {
         })();
     
     this.jobDefinition = new batch.CfnJobDefinition(this, 'JobDefinition', {
-      jobDefinitionName: `TAK-${envConfig.stackName}-CloudTAK-data-job`,
+      jobDefinitionName: `TAK-${envConfig.stackName}-CloudTAK-data-job-${cdk.Names.uniqueId(this).slice(-8)}`,
       type: 'container',
       platformCapabilities: ['FARGATE'],
       retryStrategy: { attempts: 1 },
@@ -142,7 +142,7 @@ export class Batch extends Construct {
     });
 
     this.jobQueue = new batch.CfnJobQueue(this, 'JobQueue', {
-      jobQueueName: `TAK-${envConfig.stackName}-CloudTAK-queue`,
+      jobQueueName: `TAK-${envConfig.stackName}-CloudTAK-queue-${cdk.Names.uniqueId(this).slice(-8)}`,
       state: 'ENABLED',
       priority: 1,
       computeEnvironmentOrder: [{


### PR DESCRIPTION
# Reorganize Test Workflows and Infrastructure Fixes

## Changes Made

### Test Workflow Reorganization
- **Moved** cloudtak-test from demo-deploy.yml to run before demo-build.yml and production-build.yml
- **Added** API testing job to cloudtak-test.yml using Docker build pattern
- **Logic**: Test code before building containers, not before deploying

### Upstream Remote Cleanup
- **Enhanced** sync-upstream.sh to remove temporary upstream remote after use
- **Preserves** existing upstream remotes while cleaning up script-added ones
- **Self-contained**: Script leaves no traces when adding upstream temporarily

### Infrastructure Fixes
- **Fixed** CDK context type conversion issues (string to number/boolean)
- **Fixed** ECR repository references in build workflows (EcrRepoArnOutput to EcrArtifactsRepoArnOutput)
- **Resolved** "7 must be a whole number of days" Duration error

## Workflow Changes

### Before
demo-deploy depends on [cdk-test, cloudtak-test] then validate-prod then build-images then deploy

### After  
demo-deploy depends on [cdk-test] then validate-prod then deploy
build-images depends on [cloudtak-test] then build

## Benefits
- Logical flow: Test code then Build containers then Deploy
- Faster feedback: Catch code issues before expensive Docker builds
- Clean scripts: No leftover upstream remotes
- Fixed deployments: Context overrides work correctly
- Comprehensive testing: API now included in test suite

## Testing
- All context parameters properly converted to expected types
- Build workflows use correct ECR repository
- Sync script cleans up after itself
- API testing integrated into CI pipeline
