### PR TITLE
Fix Batch Resource Replacement on Environment Switch

### DIFF
--- a/cdk/lib/constructs/batch.ts
+++ b/cdk/lib/constructs/batch.ts
@@ -154,5 +154,11 @@ export class Batch extends Construct {
     // Add dependencies
     this.jobDefinition.addDependency(this.computeEnvironment);
     this.jobQueue.addDependency(this.computeEnvironment);
+
+    // Exclude Batch resources from environment-specific tags to prevent replacement
+    // when switching between prod and dev-test environments
+    cdk.Tags.of(this.computeEnvironment).remove('Environment Type');
+    cdk.Tags.of(this.jobDefinition).remove('Environment Type');
+    cdk.Tags.of(this.jobQueue).remove('Environment Type');
   }
 }

--- a/cdk/lib/constructs/cloudtak-api.ts
+++ b/cdk/lib/constructs/cloudtak-api.ts
@@ -180,7 +180,8 @@ export class CloudTakApi extends Construct {
                 'logs:DeleteLogGroup',
                 'logs:CreateLogGroup',
                 'logs:PutRetentionPolicy',
-                'logs:TagResource'
+                'logs:TagResource',
+                'logs:ListTagsForResource'
               ],
               resources: [
                 `arn:${cdk.Stack.of(this).partition}:logs:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:log-group:/aws/batch/job*`,


### PR DESCRIPTION
# Fix Batch Resource Replacement on Environment Switch

## Problem
AWS Batch resources require replacement when the "Environment Type" tag changes between "Prod" and "Dev-Test", causing deployment failures and service interruption.

## Solution
- Exclude Batch resources from environment-specific tagging
- Add missing CloudWatch Logs tagging permission

## Changes
- **batch.ts**: Remove "Environment Type" tag from Batch resources
- **cloudtak-api.ts**: Add `logs:ListTagsForResource` permission

## Testing
- Verified tag removal prevents replacement requirement
- Confirmed Batch functionality remains intact
- Fixed CloudWatch Logs tagging permission error

Fixes deployment switching between environments without Batch service interruption.
