### PR TITLE
Add Missing Context Overrides and Make CloudWatch Logs Configurable

### DIFF
--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -28,7 +28,8 @@
         "enablePerformanceInsights": false,
         "monitoringInterval": 0,
         "backupRetentionDays": 7,
-        "deleteProtection": false
+        "deleteProtection": false,
+        "enableCloudWatchLogs": false
       },
       "ecs": {
         "taskCpu": 1024,
@@ -66,7 +67,8 @@
         "enablePerformanceInsights": true,
         "monitoringInterval": 60,
         "backupRetentionDays": 30,
-        "deleteProtection": true
+        "deleteProtection": true,
+        "enableCloudWatchLogs": false
       },
       "ecs": {
         "taskCpu": 2048,

--- a/cdk/lib/constructs/database.ts
+++ b/cdk/lib/constructs/database.ts
@@ -174,7 +174,7 @@ export class Database extends Construct {
         },
         deletionProtection: props.envConfig.database.deleteProtection,
         removalPolicy: removalPolicy,
-        cloudwatchLogsExports: ['postgresql'],
+        cloudwatchLogsExports: props.envConfig.database.enableCloudWatchLogs ? ['postgresql'] : undefined,
         cloudwatchLogsRetention: props.envConfig.general.enableDetailedLogging ? 
           logs.RetentionDays.ONE_MONTH : 
           logs.RetentionDays.ONE_WEEK,
@@ -227,7 +227,7 @@ export class Database extends Construct {
         },
         deletionProtection: props.envConfig.database.deleteProtection,
         removalPolicy: removalPolicy,
-        cloudwatchLogsExports: ['postgresql'],
+        cloudwatchLogsExports: props.envConfig.database.enableCloudWatchLogs ? ['postgresql'] : undefined,
         cloudwatchLogsRetention: props.envConfig.general.enableDetailedLogging ? 
           logs.RetentionDays.ONE_MONTH : 
           logs.RetentionDays.ONE_WEEK,

--- a/cdk/lib/stack-config.ts
+++ b/cdk/lib/stack-config.ts
@@ -19,6 +19,7 @@ export interface ContextEnvironmentConfig {
     monitoringInterval: number;
     backupRetentionDays: number;
     deleteProtection: boolean;
+    enableCloudWatchLogs?: boolean;
   };
   ecs: {
     taskCpu: number;

--- a/cdk/lib/utils/context-overrides.ts
+++ b/cdk/lib/utils/context-overrides.ts
@@ -27,6 +27,7 @@ export function applyContextOverrides(
       monitoringInterval: app.node.tryGetContext('monitoringInterval') ? Number(app.node.tryGetContext('monitoringInterval')) : baseConfig.database.monitoringInterval,
       backupRetentionDays: app.node.tryGetContext('backupRetentionDays') ? Number(app.node.tryGetContext('backupRetentionDays')) : baseConfig.database.backupRetentionDays,
       deleteProtection: app.node.tryGetContext('deleteProtection') ? app.node.tryGetContext('deleteProtection') === 'true' : baseConfig.database.deleteProtection,
+      enableCloudWatchLogs: app.node.tryGetContext('enableCloudWatchLogs') ? app.node.tryGetContext('enableCloudWatchLogs') === 'true' : baseConfig.database.enableCloudWatchLogs,
     },
     ecs: {
       ...baseConfig.ecs,
@@ -39,6 +40,8 @@ export function applyContextOverrides(
     cloudtak: {
       ...baseConfig.cloudtak,
       hostname: app.node.tryGetContext('hostname') ?? baseConfig.cloudtak.hostname,
+      takAdminEmail: app.node.tryGetContext('takAdminEmail') ?? baseConfig.cloudtak.takAdminEmail,
+      useS3CloudTAKConfigFile: app.node.tryGetContext('useS3CloudTAKConfigFile') ? app.node.tryGetContext('useS3CloudTAKConfigFile') === 'true' : baseConfig.cloudtak.useS3CloudTAKConfigFile,
     },
     ecr: {
       ...baseConfig.ecr,

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -149,12 +149,14 @@ Use CDK's built-in `--context` flag with **flat parameter names** to override an
 | `enablePerformanceInsights` | Enable performance insights | `false` | `true` |
 | `backupRetentionDays` | Backup retention period (days) | `7` | `30` |
 | `deleteProtection` | Enable deletion protection | `false` | `true` |
+| `enableCloudWatchLogs` | Enable PostgreSQL logs export to CloudWatch | `false` | `false` |
 
 ### **CloudTAK Configuration**
 | Parameter | Description | dev-test | prod |
 |-----------|-------------|----------|------|
 | `hostname` | Hostname for CloudTAK service | `map` | `map` |
 | `takAdminEmail` | Admin email address | `admin@tak.nz` | `admin@tak.nz` |
+| `useS3CloudTAKConfigFile` | Load config from S3 bucket | `false` | `true` |
 
 ### **ECR Configuration**
 | Parameter | Description | dev-test | prod |
@@ -198,6 +200,12 @@ npm run deploy:dev -- \
 npm run deploy:prod -- \
   --context imageRetentionCount=30 \
   --context scanOnPush=false
+
+# Enable PostgreSQL logs export to CloudWatch
+npm run deploy:dev -- --context enableCloudWatchLogs=true
+
+# Enable S3 config file loading in development
+npm run deploy:dev -- --context useS3CloudTAKConfigFile=true
 ```
 
 ---


### PR DESCRIPTION
## Changes
- Added `enableCloudWatchLogs` option to database configuration
  - Set default to `false` for both dev-test and prod environments
  - Updated database construct to conditionally enable log exports
- Added missing context override for `useS3CloudTAKConfigFile`
- Added missing context override for `takAdminEmail`
- Updated documentation in PARAMETERS.md with new options and examples

## Why
- CloudWatch logs export for PostgreSQL can increase costs significantly
- Making it configurable allows users to enable it only when needed
- Fixed missing context overrides to ensure all configuration options can be overridden via command line

## How to Test
1. Deploy with logs enabled:
   ```bash
   npm run deploy:dev -- --context enableCloudWatchLogs=true
```
2. Deploy with S3 config file in development:
```bash
npm run deploy:dev -- --context useS3CloudTAKConfigFile=true
```
Related Issues
Fixes missing context overrides for CloudTAK configuration

Improves cost control for database logging