### PR TITLE
GitHub Workflows Update

### DIFF
--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup CDK Environment'
-description: 'Setup Node.js, AWS credentials, and install CDK dependencies'
+description: 'Common setup steps for CDK workflows: checkout, Node.js, AWS credentials, and npm install'
 
 inputs:
   aws-role-arn:
@@ -10,7 +10,8 @@ inputs:
     required: true
   role-session-name:
     description: 'AWS role session name'
-    required: true
+    required: false
+    default: 'GitHubActions'
 
 runs:
   using: 'composite'
@@ -18,7 +19,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '22'
         cache: 'npm'
         cache-dependency-path: 'cdk/package-lock.json'
 
@@ -29,14 +30,8 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         role-session-name: ${{ inputs.role-session-name }}
 
-    - name: Install CDK dependencies
+    - name: Install dependencies
       shell: bash
       run: |
         cd cdk
         npm ci
-
-    - name: Build CDK project
-      shell: bash
-      run: |
-        cd cdk
-        npm run build

--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -54,15 +54,15 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.DEMO_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.DEMO_AWS_REGION }}
           role-session-name: GitHubActions-DockerBuild
       
       - name: Get ECR Repository and Build Tags
         id: tags
         run: |
           ECR_REPO_ARN=$(aws cloudformation describe-stacks \
-            --stack-name TAK-${{ vars.STACK_NAME }}-BaseInfra \
+            --stack-name TAK-${{ vars.DEMO_STACK_NAME }}-BaseInfra \
             --query 'Stacks[0].Outputs[?OutputKey==`EcrArtifactsRepoArnOutput`].OutputValue' \
             --output text)
           
@@ -72,7 +72,7 @@ jobs:
           fi
           
           ECR_REPO_NAME=$(echo $ECR_REPO_ARN | cut -d'/' -f2)
-          ECR_REPO_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
+          ECR_REPO_URI="${{ secrets.DEMO_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.DEMO_AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
           
           # Create deterministic hash based on actual file contents
           CONTENT_SHA=$(find api/ tasks/ -type f -exec sha256sum {} \; | sort | sha256sum | cut -c1-8)
@@ -97,7 +97,7 @@ jobs:
       
       - name: Login to Amazon ECR
         run: |
-          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \
+          aws ecr get-login-password --region ${{ secrets.DEMO_AWS_REGION }} | \
             docker login --username AWS --password-stdin \
             ${{ steps.tags.outputs.ecr-repo-uri }}
       

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -44,14 +44,14 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.DEMO_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.DEMO_AWS_REGION }}
           role-session-name: GitHubActions-Demo
 
       - name: Validate CDK Synthesis (Prod Profile)
         run: |
           cd cdk
-          npm run cdk synth -- --context envType=prod --context stackName=${{ vars.STACK_NAME }}
+          npm run cdk synth -- --context envType=prod --context stackName=${{ vars.DEMO_STACK_NAME }}
 
       - name: Validate Change Set
         run: |
@@ -59,7 +59,7 @@ jobs:
           if [[ "${{ github.event.head_commit.message }}" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
-            ./scripts/github/validate-changeset.sh TAK-${{ vars.STACK_NAME }}-CloudTAK
+            ./scripts/github/validate-changeset.sh TAK-${{ vars.DEMO_STACK_NAME }}-CloudTAK
           fi
 
   # Deploy demo environment with production configuration for testing
@@ -77,8 +77,8 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.DEMO_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.DEMO_AWS_REGION }}
           role-session-name: GitHubActions-Demo
 
       - name: Extract Image Tags
@@ -102,7 +102,7 @@ jobs:
       - name: Deploy Demo with Prod Profile
         run: |
           cd cdk
-          npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context usePreBuiltImages=true --context cloudtakImageTag=${{ steps.images.outputs.cloudtak-tag }} --context useS3CloudTAKConfigFile=false ${{ steps.db-config.outputs.db-context }} --require-approval never
+          npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.DEMO_STACK_NAME }} --context usePreBuiltImages=true --context cloudtakImageTag=${{ steps.images.outputs.cloudtak-tag }} --context useS3CloudTAKConfigFile=false ${{ steps.db-config.outputs.db-context }} --require-approval never
 
       - name: Wait for Testing Period
         run: sleep ${{ vars.DEMO_TEST_DURATION || '300' }}
@@ -112,7 +112,7 @@ jobs:
           echo "Placeholder for automated tests"
           # TODO: Add health checks and integration tests
           # Health check URL should be retrieved from BaseInfra stack outputs
-          # curl -f https://$(aws cloudformation describe-stacks --stack-name TAK-${{ vars.STACK_NAME }}-BaseInfra --query 'Stacks[0].Outputs[?OutputKey==`DomainNameOutput`].OutputValue' --output text)/health || exit 1
+          # curl -f https://$(aws cloudformation describe-stacks --stack-name TAK-${{ vars.DEMO_STACK_NAME }}-BaseInfra --query 'Stacks[0].Outputs[?OutputKey==`DomainNameOutput`].OutputValue' --output text)/health || exit 1
 
   # Always revert demo environment back to dev-test configuration
   # Ensures demo environment is left in a consistent state regardless of test results
@@ -128,16 +128,16 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.DEMO_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.DEMO_AWS_REGION }}
           role-session-name: GitHubActions-Demo
 
       - name: Validate CDK Synthesis (Dev-Test Profile)
         run: |
           cd cdk
-          npm run cdk synth -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }}
+          npm run cdk synth -- --context envType=dev-test --context stackName=${{ vars.DEMO_STACK_NAME }}
 
       - name: Revert Demo to Dev-Test Profile
         run: |
           cd cdk
-          npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context usePreBuiltImages=true --context cloudtakImageTag=${{ needs.deploy-and-test.outputs.cloudtak-tag }} --context useS3CloudTAKConfigFile=true --require-approval never
+          npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.DEMO_STACK_NAME }} --context usePreBuiltImages=true --context cloudtakImageTag=${{ needs.deploy-and-test.outputs.cloudtak-tag }} --context useS3CloudTAKConfigFile=true --require-approval never

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -49,15 +49,15 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.PROD_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PROD_AWS_REGION }}
           role-session-name: GitHubActions-DockerBuild
       
       - name: Get ECR Repository and Build Tags
         id: tags
         run: |
           ECR_REPO_ARN=$(aws cloudformation describe-stacks \
-            --stack-name TAK-${{ vars.STACK_NAME }}-BaseInfra \
+            --stack-name TAK-${{ vars.PROD_STACK_NAME }}-BaseInfra \
             --query 'Stacks[0].Outputs[?OutputKey==`EcrArtifactsRepoArnOutput`].OutputValue' \
             --output text)
           
@@ -67,7 +67,7 @@ jobs:
           fi
           
           ECR_REPO_NAME=$(echo $ECR_REPO_ARN | cut -d'/' -f2)
-          ECR_REPO_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
+          ECR_REPO_URI="${{ secrets.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.PROD_AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
           
           # Create deterministic hash based on actual file contents
           CONTENT_SHA=$(find api/ tasks/ -type f -exec sha256sum {} \; | sort | sha256sum | cut -c1-8)
@@ -92,7 +92,7 @@ jobs:
       
       - name: Login to Amazon ECR
         run: |
-          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \
+          aws ecr get-login-password --region ${{ secrets.PROD_AWS_REGION }} | \
             docker login --username AWS --password-stdin \
             ${{ steps.tags.outputs.ecr-repo-uri }}
       

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -43,15 +43,15 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.PROD_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PROD_AWS_REGION }}
           role-session-name: GitHubActions-Production
 
       - name: Bootstrap CDK (if needed)
         run: |
           cd cdk
           if ! aws cloudformation describe-stacks --stack-name CDKToolkit 2>/dev/null; then
-            npx cdk bootstrap aws://${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.AWS_REGION }} --context envType=prod
+            npx cdk bootstrap aws://${{ secrets.PROD_AWS_ACCOUNT_ID }}/${{ secrets.PROD_AWS_REGION }} --context envType=prod
           fi
 
       - name: Extract Image Tags
@@ -66,10 +66,10 @@ jobs:
           if [[ "${{ github.event.head_commit.message }}" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
-            ./scripts/github/validate-changeset.sh TAK-${{ vars.STACK_NAME }}-CloudTAK
+            ./scripts/github/validate-changeset.sh TAK-${{ vars.PROD_STACK_NAME }}-CloudTAK
           fi
 
       - name: Deploy Production
         run: |
           cd cdk
-          npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context usePreBuiltImages=true --context cloudtakImageTag=${{ steps.images.outputs.cloudtak-tag }} --require-approval never
+          npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.PROD_STACK_NAME }} --context usePreBuiltImages=true --context cloudtakImageTag=${{ steps.images.outputs.cloudtak-tag }} --require-approval never

--- a/docs/AWS_GITHUB_SETUP.md
+++ b/docs/AWS_GITHUB_SETUP.md
@@ -8,6 +8,8 @@ This guide covers setting up GitHub Actions for the CloudTAK repository, buildin
 - Route 53 DNS setup
 - GitHub OIDC Identity Provider and IAM roles
 
+> **Note:** The organization variables and secrets configured in BaseInfra will be used for both environments.
+
 ## 3. GitHub Environment Setup for CloudTAK
 
 ### 3.1 Create Environments
@@ -25,25 +27,49 @@ In your CloudTAK GitHub repository, go to **Settings → Environments** and crea
    - **Protection rules:**
      - Deployment branches and tags: Select "Selected branches and tags"
        - Add rule: "main"
-   - **Environment variables:**
-     - `DEMO_TEST_DURATION`: `300` (wait time in seconds, default 5 minutes)
-     - `STACK_NAME`: `Demo`
 
-### 3.2 Configure Environment Secrets
+## 4. Branch Protection Setup
 
-**For `production` environment:**
-- `AWS_ACCOUNT_ID`: `111111111111`
-- `AWS_ROLE_ARN`: `arn:aws:iam::111111111111:role/GitHubActions-TAK-Role`
-- `AWS_REGION`: `ap-southeast-6`
+**Configure branch protection for `main`** to ensure only tested code is deployed:
 
-**For `demo` environment:**
-- `AWS_ACCOUNT_ID`: `222222222222`
-- `AWS_ROLE_ARN`: `arn:aws:iam::222222222222:role/GitHubActions-TAK-Role`
-- `AWS_REGION`: `ap-southeast-2`
+1. Go to **Settings → Branches → Add rule**
+2. **Branch name pattern**: `main`
+3. **Enable these protections:**
+   - ☑️ Require a pull request before merging
+   - ☑️ Require status checks to pass before merging
+     - ☑️ Require branches to be up to date before merging
+     - ☑️ Status checks: Select "Test CDK code" after first workflow run
 
-## 4. GitHub Actions Workflows
+## 5. Breaking Change Detection for CloudTAK
 
-### 4.1 Workflow Architecture
+### 5.1 CloudTAK-Specific Breaking Changes
+
+**Critical resources that trigger breaking change detection:**
+- PostgreSQL database cluster replacements
+- API Gateway replacements
+- Application Load Balancer replacements
+- Secrets Manager secret deletions
+- ECS service configuration changes
+- AWS Batch job definition changes
+
+### 5.2 Implementation
+
+CloudTAK uses the same breaking change detection system as BaseInfra:
+
+1. **Stage 1 (PR Level)**: CDK diff analysis during pull requests - fast feedback
+2. **Stage 2 (Deploy Level)**: CloudFormation change set validation before demo deployment - comprehensive validation
+
+### 5.3 Override Mechanism
+
+To deploy breaking changes intentionally:
+
+1. **Include `[force-deploy]` in commit message**
+2. **The workflows will detect the override and proceed with deployment**
+3. **Use with caution** - ensure dependent stacks are updated accordingly
+
+## 6. GitHub Actions Workflows
+
+### 6.1 Workflow Architecture
 
 ```mermaid
 graph TD
@@ -63,7 +89,7 @@ graph TD
     L --> M[Deploy Production]
 ```
 
-### 4.2 Demo Testing Workflow (`demo-deploy.yml`)
+### 6.2 Demo Testing Workflow (`demo-deploy.yml`)
 
 **Triggers:**
 - Push to `main` branch
@@ -76,7 +102,7 @@ graph TD
 4. **deploy-and-test**: Deploy with prod profile and run tests
 5. **revert-to-dev-test**: Always revert to dev-test configuration
 
-### 4.3 Production Deployment Workflow (`production-deploy.yml`)
+### 6.3 Production Deployment Workflow (`production-deploy.yml`)
 
 **Triggers:**
 - Version tags (`v*`)
@@ -87,7 +113,7 @@ graph TD
 2. **build-images**: Sync upstream, apply branding, build production images
 3. **deploy-production**: Deploy to production with built images (requires approval)
 
-### 4.4 Weekly Upstream Sync (`weekly-sync.yml`)
+### 6.4 Weekly Upstream Sync (`weekly-sync.yml`)
 
 **Triggers:**
 - Schedule: Saturday 2AM NZST (14:00 UTC)
@@ -106,7 +132,7 @@ graph TD
 
 **Note:** Branding is now applied at build time, not during sync. This keeps the main branch clean with upstream code only.
 
-### 4.5 Image Building with Conditional Branding
+### 6.5 Image Building with Conditional Branding
 
 **Build Process:**
 1. Checkout clean upstream code from main branch
@@ -119,54 +145,96 @@ graph TD
 - `APPLY_BRANDING=false` - Build with clean upstream code
 - Allows testing both branded and unbranded versions
 
-## 5. Required Secrets and Variables
+## 7. Required Secrets and Variables
 
-**Environment Secrets (per environment):**
+### 7.1 Organization Secrets (configured in BaseInfra)
 
-| Secret | Description | Example |
-|--------|-------------|---------|
-| `AWS_ACCOUNT_ID` | AWS account ID | `123456789012` |
-| `AWS_ROLE_ARN` | GitHub Actions IAM role ARN | `arn:aws:iam::123456789012:role/GitHubActions-TAK-Role` |
-| `AWS_REGION` | AWS deployment region | `ap-southeast-2` |
+| Secret | Description | Used For |
+|--------|-------------|----------|
+| `DEMO_AWS_ACCOUNT_ID` | Demo AWS account ID | Demo environment |
+| `DEMO_AWS_ROLE_ARN` | Demo GitHub Actions IAM role ARN | Demo environment |
+| `DEMO_AWS_REGION` | Demo AWS deployment region | Demo environment |
+| `PROD_AWS_ACCOUNT_ID` | Production AWS account ID | Production environment |
+| `PROD_AWS_ROLE_ARN` | Production GitHub Actions IAM role ARN | Production environment |
+| `PROD_AWS_REGION` | Production AWS deployment region | Production environment |
 
-**Environment Variables:**
+### 7.2 Organization Variables (configured in BaseInfra)
 
-| Variable | Environment | Description | Example | Required |
-|----------|-------------|-------------|---------|----------|
-| `STACK_NAME` | demo, prod | Stack name suffix | `Demo`, `Prod` | ✅ |
-| `DEMO_TEST_DURATION` | demo | Test wait time in seconds | `300` | ❌ |
+| Variable | Description | Used For |
+|----------|-------------|----------|
+| `DEMO_STACK_NAME` | Stack name suffix for demo | Demo environment |
+| `DEMO_TEST_DURATION` | Test wait time in seconds | Demo environment |
+| `DEMO_R53_ZONE_NAME` | Demo Route53 zone name | Demo environment |
 
-**Repository Variables:**
+### 7.3 Repository Variables
 
 | Variable | Description | Values | Usage |
 |----------|-------------|--------|-------|
 | `SYNC_MODE` | Controls weekly upstream sync behavior | `main`, `tag`, or unset | `main` = sync with main branch, `tag` = sync with latest version tag, unset = disabled |
 | `APPLY_BRANDING` | Controls whether TAK.NZ branding is applied during image builds | `true`, `false` | `true` = apply branding at build time, `false` = build with upstream code only |
 
-## 6. Verification
+## 8. Composite Actions
+
+### 8.1 Setup CDK Environment Action
+
+Location: `.github/actions/setup-cdk/action.yml`
+
+**Purpose:** Reduces code duplication by consolidating common setup steps:
+- Repository checkout
+- Node.js setup with npm caching
+- AWS credentials configuration
+- Dependency installation
+
+**Benefits:**
+- Consistent setup across all workflows
+- Easier maintenance and updates
+- Reduced workflow file size
+- Centralized Node.js and AWS configuration
+
+## 9. Verification
 
 Test the CloudTAK setup:
 
 1. **Demo Testing:** Push to `main` branch → Should sync upstream → Build images → Deploy demo → Test → Revert
 2. **Production:** Create and push version tag:
-   ```bash
+   ```
    git tag v1.0.0
    git push origin v1.0.0
    ```
    → Should require approval → Deploy after approval
 
-## 7. Troubleshooting
+### 9.1 Deployment Flow
 
-### 7.1 Common Issues
+**Main Branch Push:**
+```
+Push to main → Tests → Demo (prod profile) → Wait → Tests → Demo (dev-test profile)
+```
+
+**Version Tag Push:**
+```
+Tag v* → Tests → Production (prod profile) [requires approval]
+```
+
+**Benefits:**
+- Cost optimization: Demo runs dev-test profile between deployments
+- Risk mitigation: Both profiles tested in demo before production
+- Separation: Independent workflows for demo testing vs production deployment
+
+## 10. Troubleshooting
+
+### 10.1 Common Workflow Issues
 
 | Issue | Symptoms | Solution |
 |-------|----------|----------|
-| **Upstream Sync Fails** | Merge conflicts in sync | Manually resolve conflicts and create PR |
-| **Missing ECR Repository** | Docker push fails | Verify BaseInfra stack is deployed |
-| **Image Build Fails** | Docker build errors | Check upstream changes and branding compatibility |
+| **Missing Secrets** | `Error: Could not assume role` | Verify organization secrets are set correctly |
+| **Missing Variables** | `Error: Required variable not set` | Ensure organization variables are configured |
+| **Breaking Changes** | Workflow stops at validation | Use `[force-deploy]` in commit message or fix changes |
+| **Image Build Fails** | Docker build errors | Check Dockerfile and build context |
 | **CDK Synthesis Fails** | `cdk synth` command fails | Verify cdk.json context values |
+| **Deployment Timeout** | Job runs for hours | Check AWS resources and add timeout settings |
+| **Composite Action Error** | `Can't find action.yml` | Ensure checkout step runs before composite action |
 
-### 7.2 CloudTAK Specific Issues
+### 10.2 CloudTAK Specific Issues
 
 **Common CloudTAK Problems:**
 
@@ -174,3 +242,36 @@ Test the CloudTAK setup:
 - **Branding Issues:** Verify branding files exist and are compatible with upstream changes
 - **API Changes:** Check for breaking changes in upstream API that affect ETL tasks
 - **Database Schema:** Verify database migrations are compatible with upstream changes
+- **Image Build Failures:** Check Docker build logs for specific errors
+- **ETL Task Failures:** Verify AWS Batch job definitions and container configurations
+
+**Troubleshooting Steps:**
+
+1. Check CloudTAK version in cdk.json
+2. Verify stack status in CloudFormation console
+3. Review stack events for specific error messages
+4. Confirm ECR images are built and tagged correctly
+5. Test database connectivity through AWS console
+6. Check ECS service logs for container startup issues
+7. Verify API Gateway endpoints and configurations
+
+### 10.3 Dependencies on BaseInfra, AuthInfra, and TakInfra
+
+**Required BaseInfra Resources:**
+- VPC and networking (subnets, security groups)
+- ECS cluster and service discovery
+- KMS keys for encryption
+- Route 53 hosted zones
+- S3 buckets for CDK assets and data storage
+- ECR repositories
+
+**Required AuthInfra Resources:**
+- PostgreSQL database cluster
+- Application Load Balancer (for OIDC integration)
+- Secrets Manager secrets (for database credentials)
+
+**Required TakInfra Resources:**
+- TAK server API endpoints
+- TAK server data sources
+
+Ensure BaseInfra, AuthInfra, and TakInfra are deployed and stable before deploying CloudTAK changes.


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to use organization secrets and variables instead of environment-specific ones, aligning with the approach used in BaseInfra, AuthInfra, and TakInfra repositories.

## Changes

- **Documentation**: Updated AWS_GITHUB_SETUP.md to align with BaseInfra documentation
- **Workflow Files**: Updated all workflow files to use organization secrets and variables
  - `demo-deploy.yml`: Use DEMO_* organization secrets and variables
  - `production-deploy.yml`: Use PROD_* organization secrets and variables
  - `demo-build.yml`: Use DEMO_* organization secrets and variables
  - `production-build.yml`: Use PROD_* organization secrets and variables
- **Composite Action**: Aligned setup-cdk action with AuthInfra
  - Updated Node.js version from 18 to 22
  - Made role-session-name optional with default value
  - Removed build step to match AuthInfra approach

## Testing

The changes have been verified to maintain the same functionality while using organization-level secrets and variables.

## Related Issues

Addresses standardization of CI/CD configuration across TAK-NZ repositories.
