### PR TITLE
# Add Media Server URL Configuration

### DIFF
--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -54,6 +54,9 @@
       },
       "s3": {
         "enableVersioning": true
+      },
+      "mediainfra": {
+        "mediaHostname": "media"
       }
     },
     "prod": {
@@ -93,6 +96,9 @@
       },
       "s3": {
         "enableVersioning": true
+      },
+      "mediainfra": {
+        "mediaHostname": "media"
       }
     },
     "tak-defaults": {

--- a/cdk/lib/cloudtak-stack.ts
+++ b/cdk/lib/cloudtak-stack.ts
@@ -372,6 +372,11 @@ export class CloudTakStack extends cdk.Stack {
       exportName: `TAK-${envConfig.stackName}-CloudTAK-EtlEcrRepoArn`
     });
 
+    new cdk.CfnOutput(this, 'MediaUrl', {
+      value: `https://${envConfig.mediainfra.mediaHostname}.${hostedZone.zoneName}:9997`,
+      exportName: `TAK-${envConfig.stackName}-CloudTAK-MediaUrl`
+    });
+
 
   }
 }

--- a/cdk/lib/constructs/cloudtak-api.ts
+++ b/cdk/lib/constructs/cloudtak-api.ts
@@ -367,7 +367,9 @@ export class CloudTakApi extends Construct {
         'CLOUDTAK_Server_auth_p12_secret_arn': cdk.Fn.importValue(createTakImportValue(envConfig.stackName, TAK_EXPORT_NAMES.TAK_ADMIN_CERT_SECRET_ARN)),
         // PR #717 - Configurable ECR and ECS names
         'ECR_TASKS_REPOSITORY_NAME': etlEcrRepository.repositoryName,
-        'ECS_CLUSTER_PREFIX': `TAK-${envConfig.stackName}-BaseInfra`
+        'ECS_CLUSTER_PREFIX': `TAK-${envConfig.stackName}-BaseInfra`,
+        // Media server URL
+        'MEDIA_URL': `https://${envConfig.mediainfra.mediaHostname}.${cdk.Fn.importValue(createBaseImportValue(envConfig.stackName, BASE_EXPORT_NAMES.HOSTED_ZONE_NAME))}:9997`
       },
       secrets: {
         'SigningSecret': ecs.Secret.fromSecretsManager(signingSecret),

--- a/cdk/lib/stack-config.ts
+++ b/cdk/lib/stack-config.ts
@@ -45,4 +45,7 @@ export interface ContextEnvironmentConfig {
   s3: {
     enableVersioning: boolean;
   };
+  mediainfra: {
+    mediaHostname: string;
+  };
 }

--- a/cdk/test/__fixtures__/mock-configs.ts
+++ b/cdk/test/__fixtures__/mock-configs.ts
@@ -26,7 +26,8 @@ export const MOCK_CONFIGS = {
     },
     cloudtak: {
       hostname: 'map',
-      takAdminEmail: 'admin@test.com'
+      takAdminEmail: 'admin@test.com',
+      useS3CloudTAKConfigFile: false
     },
     ecr: {
       imageRetentionCount: 5,
@@ -39,6 +40,9 @@ export const MOCK_CONFIGS = {
     },
     s3: {
       enableVersioning: false
+    },
+    mediainfra: {
+      mediaHostname: 'media'
     }
   } as ContextEnvironmentConfig,
 
@@ -64,7 +68,8 @@ export const MOCK_CONFIGS = {
     },
     cloudtak: {
       hostname: 'map',
-      takAdminEmail: 'admin@prod.com'
+      takAdminEmail: 'admin@prod.com',
+      useS3CloudTAKConfigFile: true
     },
     ecr: {
       imageRetentionCount: 20,
@@ -77,6 +82,9 @@ export const MOCK_CONFIGS = {
     },
     s3: {
       enableVersioning: true
+    },
+    mediainfra: {
+      mediaHostname: 'media'
     }
   } as ContextEnvironmentConfig,
 
@@ -100,7 +108,8 @@ export const MOCK_CONFIGS = {
     },
     cloudtak: {
       hostname: 'test',
-      takAdminEmail: 'test@example.com'
+      takAdminEmail: 'test@example.com',
+      useS3CloudTAKConfigFile: false
     },
     ecr: {
       imageRetentionCount: 1,
@@ -113,6 +122,9 @@ export const MOCK_CONFIGS = {
     },
     s3: {
       enableVersioning: false
+    },
+    mediainfra: {
+      mediaHostname: 'media'
     }
   } as ContextEnvironmentConfig
 };


### PR DESCRIPTION
## Summary
Adds configuration and integration for media server URL to support MediaInfra layer integration.

## Changes
- **Configuration**: Added `mediainfra.mediaHostname` setting to both dev-test and prod environments (defaults to "media")
- **Environment Variable**: CloudTAK ECS container now receives `MEDIA_URL` in format `https://{mediaHostname}.{domain}:9997`
- **CloudFormation Export**: Added `TAK-{stackName}-CloudTAK-MediaUrl` export for other stacks to import

## Testing
- [X] Verify CDK synthesis passes
- [ ] Confirm environment variable is available in CloudTAK container
- [ ] Validate CloudFormation export is created correctly

## Impact
- Enables CloudTAK to connect to MediaInfra video streaming services
- Maintains backward compatibility with existing deployments
- Supports both dev (`media.dev.tak.nz:9997`) and prod (`media.tak.nz:9997`) environments
