### PR TITLE
Add Comprehensive MediaMTX Streaming Protocol Support

### DIFF
--- a/cdk/lib/constructs/security-groups.ts
+++ b/cdk/lib/constructs/security-groups.ts
@@ -78,6 +78,24 @@ export class SecurityGroups extends Construct {
     this.ecs.addEgressRule(ec2.Peer.ipv6(vpcCidrIpv6), ec2.Port.tcp(8089), 'TAK Streaming CoT IPv6');
     this.ecs.addEgressRule(ec2.Peer.ipv6(vpcCidrIpv6), ec2.Port.tcp(8443), 'TAK Server API IPv6');
     this.ecs.addEgressRule(ec2.Peer.ipv6(vpcCidrIpv6), ec2.Port.tcp(8446), 'TAK Server WebTAK IPv6');
+    // Media server connections
+    this.ecs.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(9997), 'Media server outbound');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv6(), ec2.Port.tcp(9997), 'Media server outbound IPv6');
+    // Additional media server protocol ports
+    this.ecs.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(1935), 'RTMP outbound');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv6(), ec2.Port.tcp(1935), 'RTMP outbound IPv6');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(8554), 'RTSP outbound');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv6(), ec2.Port.tcp(8554), 'RTSP outbound IPv6');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(1936), 'RTMPS outbound');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv6(), ec2.Port.tcp(1936), 'RTMPS outbound IPv6');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(8555), 'RTSPS outbound');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv6(), ec2.Port.tcp(8555), 'RTSPS outbound IPv6');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.udp(8890), 'SRT outbound');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv6(), ec2.Port.udp(8890), 'SRT outbound IPv6');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(8888), 'HLS outbound');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv6(), ec2.Port.tcp(8888), 'HLS outbound IPv6');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(9996), 'Media server playback outbound');
+    this.ecs.addEgressRule(ec2.Peer.anyIpv6(), ec2.Port.tcp(9996), 'Media server playback outbound IPv6');
 
 
   }


### PR DESCRIPTION
## Problem
CloudTAK's ECS security group only had basic media server connectivity (port 9997) but lacked egress rules for the full range of streaming protocols supported by MediaMTX. This prevented CloudTAK from connecting to external streaming sources using different protocols.

## Solution
Added comprehensive egress rules for all MediaMTX streaming protocols with dual-stack IPv4/IPv6 support:

### 🎥 **Streaming Protocols Added**
- **RTMP** (port 1935) - Real-Time Messaging Protocol
- **RTMPS** (port 1936) - RTMP over SSL/TLS
- **RTSP** (port 8554) - Real-Time Streaming Protocol  
- **RTSPS** (port 8555) - RTSP over SSL/TLS
- **SRT** (port 8890 UDP) - Secure Reliable Transport
- **HLS** (port 8888) - HTTP Live Streaming
- **Playback** (port 9996) - Media server playback API

### 🌐 **Dual-Stack Support**
- All protocols support both IPv4 and IPv6 connectivity
- Consistent naming convention for IPv6 rules
- Future-proof networking compatibility

## Benefits
- **Protocol Flexibility**: CloudTAK can now connect to streaming sources using any MediaMTX-supported protocol
- **External Integration**: Enables proxy streaming from external RTMP/RTSP/SRT sources
- **IPv6 Ready**: Full dual-stack support for modern networking
- **Security**: Maintains least-privilege principle with specific port access only

## Testing
- [x] CDK synthesis passes
- [x] Security group rules validate correctly
- [x] IPv4/IPv6 dual-stack configuration verified
- [x] Port mappings match MediaMTX defaults

This enables CloudTAK's video lease system to proxy streams from external sources using the full range of modern streaming protocols.
