### PR TITLE
Fix GitHub Actions Bash Syntax Error

### DIFF
--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -61,7 +61,8 @@ jobs:
         run: |
           # Check if override is requested
           OVERRIDE="false"
-          if [[ "${{ github.event.head_commit.message }}" == *"[force-deploy]"* ]]; then
+          COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
+          if [[ "$COMMIT_MESSAGE" == *"[force-deploy]"* ]]; then
             OVERRIDE="true"
           fi
           ./scripts/github/check-breaking-changes.sh cloudtak prod $OVERRIDE


### PR DESCRIPTION
Summary: Resolves bash conditional syntax error in cdk-test.yml workflow caused by multi-line commit messages.

Problem:
- GitHub Actions workflow failing with "conditional binary operator expected" error
- Multi-line commit messages break bash conditional syntax when directly substituted
- Workflow unable to check for [force-deploy] flag in commit messages

Solution:
- Store commit message in COMMIT_MESSAGE variable first
- Use variable in conditional instead of direct GitHub context substitution
- Prevents bash syntax errors from newlines and special characters in commit messages

Impact:
- Fixes broken CI/CD pipeline for commits with multi-line messages
- Restores [force-deploy] flag functionality for breaking change overrides
- Ensures workflow can properly parse commit messages for deployment flags
