### PR TITLE
feat: add TAK.NZ security headers via branding script

### DIFF
--- a/scripts/apply-branding.sh
+++ b/scripts/apply-branding.sh
@@ -39,4 +39,16 @@ if [ -f "api/web/src/App.vue" ]; then
     echo "✅ Updated App.vue branding"
 fi
 
+# Add security headers to nginx configuration
+if [ -f "api/nginx.conf.js" ]; then
+    # Add TAK.NZ security headers after the existing add_header lines
+    sed -i.bak "/add_header 'Permissions-Policy'/a\\
+        add_header 'Reporting-Endpoints' 'default=\"https://tak-nz.uriports.com/reports\"' always;\\
+        add_header 'Report-To' '{\"group\":\"default\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"https://tak-nz.uriports.com/reports\"}],\"include_subdomains\":true}' always;\\
+        add_header 'NEL' '{\"report_to\":\"default\",\"max_age\":2592000,\"include_subdomains\":true,\"failure_fraction\":1.0}' always;\\
+        add_header 'Permissions-Policy-Report-Only' 'microphone=();report-to=default, camera=(self \"https://www.example.com\");report-to=default, fullscreen=*;report-to=default, payment=self;report-to=default' always;\\
+        add_header 'Content-Security-Policy-Report-Only' 'default-src \'self\'; font-src \'self\'; img-src \'self\'; script-src \'self\'; style-src \'self\'; frame-ancestors \'self\'; report-uri https://tak-nz.uriports.com/reports/report; report-to default' always;" api/nginx.conf.js
+    echo "✅ Added TAK.NZ security headers to nginx configuration"
+fi
+
 echo "🎉 TAK.NZ branding applied successfully"


### PR DESCRIPTION
- Add Reporting-Endpoints header for CSP/NEL reporting
- Add Report-To header for structured reporting configuration
- Add NEL (Network Error Logging) header for network monitoring
- Add Permissions-Policy-Report-Only for policy violation reporting
- Add Content-Security-Policy-Report-Only for CSP violation reporting
- Headers automatically applied after upstream syncs via apply-branding.sh
- All reports sent to https://tak-nz.uriports.com/reports endpoint

This ensures security monitoring headers persist across upstream syncs
by integrating them into the existing TAK.NZ customization workflow.