### PR TITLE
Add TAK.NZ Security Headers via Branding Script

### DIFF
--- a/scripts/apply-branding.sh
+++ b/scripts/apply-branding.sh
@@ -39,4 +39,16 @@ if [ -f "api/web/src/App.vue" ]; then
     echo "✅ Updated App.vue branding"
 fi
 
+# Add security headers to nginx configuration
+if [ -f "api/nginx.conf.js" ]; then
+    # Add TAK.NZ security headers after the existing add_header lines
+    sed -i.bak "/add_header 'Permissions-Policy'/a\\
+        add_header 'Reporting-Endpoints' 'default=\"https://tak-nz.uriports.com/reports\"' always;\\
+        add_header 'Report-To' '{\"group\":\"default\",\"max_age\":10886400,\"endpoints\":[{\"url\":\"https://tak-nz.uriports.com/reports\"}],\"include_subdomains\":true}' always;\\
+        add_header 'NEL' '{\"report_to\":\"default\",\"max_age\":2592000,\"include_subdomains\":true,\"failure_fraction\":1.0}' always;\\
+        add_header 'Permissions-Policy-Report-Only' 'microphone=();report-to=default, camera=(self \"https://www.example.com\");report-to=default, fullscreen=*;report-to=default, payment=self;report-to=default' always;\\
+        add_header 'Content-Security-Policy-Report-Only' 'default-src \'self\'; font-src \'self\'; img-src \'self\'; script-src \'self\'; style-src \'self\'; frame-ancestors \'self\'; report-uri https://tak-nz.uriports.com/reports/report; report-to default' always;" api/nginx.conf.js
+    echo "✅ Added TAK.NZ security headers to nginx configuration"
+fi
+
 echo "🎉 TAK.NZ branding applied successfully"


### PR DESCRIPTION
## 🔒 Security Enhancement

Adds comprehensive security monitoring headers to CloudTAK that persist across upstream syncs by integrating them into the existing `apply-branding.sh` workflow.

## 📋 Headers Added

- **Reporting-Endpoints**: `default="https://tak-nz.uriports.com/reports"`
- **Report-To**: Structured reporting configuration with 126-day max age
- **NEL**: Network Error Logging with 30-day retention and full failure reporting
- **Permissions-Policy-Report-Only**: Policy violation monitoring for microphone, camera, fullscreen, payment
- **Content-Security-Policy-Report-Only**: CSP violation reporting with strict policy

## 🔧 Implementation

- Headers added to `nginx.conf.js` via `scripts/apply-branding.sh`
- Automatically applied after each upstream sync
- All violation reports sent to `https://tak-nz.uriports.com/reports`
- Uses report-only policies to avoid breaking existing functionality

## ✅ Benefits

- **Sync-Safe**: Headers persist across upstream updates
- **Comprehensive Monitoring**: Covers CSP, permissions, and network errors
- **Non-Breaking**: Report-only policies don't affect user experience
- **Centralized Reporting**: Single endpoint for all security telemetry

## 🧪 Testing

Headers will be applied during next Docker build after running branding script.
