### PR TITLE
Fix: Prevent Shell Injection in GitHub Workflow

### DIFF
--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           # Check if override is requested
           OVERRIDE="false"
-          COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
+          COMMIT_MESSAGE='${{ github.event.head_commit.message }}'
           if [[ "$COMMIT_MESSAGE" == *"[force-deploy]"* ]]; then
             OVERRIDE="true"
           fi


### PR DESCRIPTION
## Problem
The GitHub workflow was failing with "command not found" errors when commit messages contained special characters like asterisks or parentheses. The commit message variable was being interpreted as shell commands due to improper quoting.

## Solution
Changed the commit message variable quoting from double quotes to single quotes to prevent shell interpretation of special characters.

## Changes
- Updated `.github/workflows/cdk-test.yml` to use single quotes around `${{ github.event.head_commit.message }}`

## Testing
This prevents shell command injection when commit messages contain special characters that could be interpreted as shell commands.
