### PR TITLE
Fix: Course Arrows Not Appearing Immediately When Icon Rotation Disabled

### DIFF
--- a/api/lib/control/profile.ts
+++ b/api/lib/control/profile.ts
@@ -55,12 +55,6 @@ export const DefaultUnits = Type.Object({
         }),
         options: Type.Array(Type.String())
     }),
-    'icon_rotation': Type.Object({
-        value: Type.String({
-            default: 'Enabled'
-        }),
-        options: Type.Array(Type.String())
-    }),
 });
 
 export default class ProfileControl {
@@ -82,7 +76,7 @@ export default class ProfileControl {
         if (!input.display_projection) input.display_projection = defaults.projection.value;
         if (!input.display_zoom) input.display_zoom = defaults.zoom.value;
         if (!input.display_text) input.display_text = defaults.text.value;
-        if (input.display_icon_rotation === undefined) input.display_icon_rotation = 'Enabled';
+        if (input.display_icon_rotation === undefined) input.display_icon_rotation = true;
 
         const profile = await this.config.models.Profile.generate(input);
 
@@ -98,7 +92,6 @@ export default class ProfileControl {
             'display::projection',
             'display::zoom',
             'display::text',
-            'display::icon_rotation',
             'display::icon_rotation',
         ];
 
@@ -144,11 +137,7 @@ export default class ProfileControl {
                 options: Object.values(Profile_Text)
             },
             icon_rotation: {
-                value: final.icon_rotation || 'Enabled',
-                options: ['Enabled', 'Disabled']
-            },
-            icon_rotation: {
-                value: final.icon_rotation || 'Enabled',
+                value: final.icon_rotation === 'false' ? false : true,
                 options: ['Enabled', 'Disabled']
             }
         }

--- a/api/lib/schema.ts
+++ b/api/lib/schema.ts
@@ -66,7 +66,7 @@ export const Profile = pgTable('profile', {
     display_speed: text().$type<Profile_Speed>().notNull().default(Profile_Speed.MPH),
     display_projection: text().$type<Profile_Projection>().notNull().default(Profile_Projection.GLOBE),
     display_zoom: text().$type<Profile_Zoom>().notNull().default(Profile_Zoom.CONDITIONAL),
-    display_icon_rotation: text().notNull().default('Enabled'),
+    display_icon_rotation: boolean().notNull().default(true),
     display_text: text().$type<Profile_Text>().notNull().default(Profile_Text.Medium),
     system_admin: boolean().notNull().default(false),
     agency_admin: json().notNull().$type<Array<number>>().default([])
@@ -117,6 +117,18 @@ export const VideoLease = pgTable('video_lease', {
     // Optional Proxy Mode
     proxy: text().default(sql`null`),
 });
+
+export const ProfileVideo = pgTable('profile_videos', {
+    id: uuid().primaryKey().default(sql`gen_random_uuid()`),
+    created: timestamp({ withTimezone: true, mode: 'string' }).notNull().default(sql`Now()`),
+    updated: timestamp({ withTimezone: true, mode: 'string' }).notNull().default(sql`Now()`),
+    lease: integer().notNull().references(() => VideoLease.id),
+    username: text().notNull().references(() => Profile.username),
+}, (table) => {
+    return {
+        username_idx: index("profile_videos_username_idx").on(table.username),
+    }
+})
 
 export const ProfileFeature = pgTable('profile_features', {
     id: text().primaryKey().notNull(),

--- a/api/migrations/0115_add_display_icon_rotation.sql
+++ b/api/migrations/0115_add_display_icon_rotation.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "profile" ADD COLUMN "display_icon_rotation" text DEFAULT 'Enabled' NOT NULL;
+ALTER TABLE "profile" ADD COLUMN "display_icon_rotation" boolean DEFAULT true NOT NULL;

--- a/api/routes/profile.ts
+++ b/api/routes/profile.ts
@@ -23,7 +23,6 @@ export default async function router(schema: Schema, config: Config) {
             res.json({
                 active: config.wsClients.has(profile.username),
                 ...profile,
-                // Convert boolean to string for API contract
                 display_icon_rotation: profile.display_icon_rotation ? 'Enabled' : 'Disabled'
             });
         } catch (err) {
@@ -43,7 +42,6 @@ export default async function router(schema: Schema, config: Config) {
             display_speed: Type.Optional(Type.Enum(Profile_Speed)),
             display_zoom: Type.Optional(Type.Enum(Profile_Zoom)),
             display_icon_rotation: Type.Optional(Type.String()),
-            display_icon_rotation: Type.Optional(Type.String()),
             display_text: Type.Optional(Type.Enum(Profile_Text)),
             tak_callsign: Type.Optional(Type.String()),
             tak_remarks: Type.Optional(Type.String()),
@@ -61,14 +59,19 @@ export default async function router(schema: Schema, config: Config) {
         try {
             const user = await Auth.as_user(config, req);
             
-            const updateData = { ...req.body, updated: sql`Now()` };
+            const updateData: any = { ...req.body, updated: sql`Now()` };
+            
+            // Convert string to boolean for database storage
+            if (updateData.display_icon_rotation !== undefined) {
+                updateData.display_icon_rotation = updateData.display_icon_rotation === 'Enabled';
+            }
+                        
             const profile = await config.models.Profile.commit(user.email, updateData);
 
             // @ts-expect-error Update Batch-Generic to specify actual geometry type (Point) instead of Geometry
             res.json({
                 active: config.wsClients.has(profile.username),
                 ...profile,
-                // Convert boolean to string for API contract
                 display_icon_rotation: profile.display_icon_rotation ? 'Enabled' : 'Disabled'
             });
         } catch (err) {


### PR DESCRIPTION
## Problem
Multiple issues with the "Rotate Icons with Course" setting:
1. Course arrows not appearing immediately when rotation disabled - required page reload
2. Setting not persisting when reopening dialog
