### PR TITLE
Fix: Admin Config Not Displaying Current Icon Rotation Setting

### DIFF
--- a/api/lib/control/profile.ts
+++ b/api/lib/control/profile.ts
@@ -137,7 +137,7 @@ export default class ProfileControl {
                 options: Object.values(Profile_Text)
             },
             icon_rotation: {
-                value: final.icon_rotation === 'false' ? false : true,
+                value: final.icon_rotation || 'Enabled',
                 options: ['Enabled', 'Disabled']
             }
         }


### PR DESCRIPTION
## Problem
The admin config page was not showing the current value for "Rotate Icons with Course" setting. It would always appear blank or show the default instead of the actual stored value.

## Root Cause
In ProfileControl.defaultUnits(), the icon_rotation value was being incorrectly converted from string to boolean instead of returning the actual database value.

## Solution
Fixed the defaultUnits() method to return the actual string value from the database:

- Before: value: final.icon_rotation === 'false' ? false : true
- After: value: final.icon_rotation || 'Enabled'

## Testing
- Admin config now displays current icon rotation setting correctly
- Shows 'Disabled' when setting is disabled in database  
- Shows 'Enabled' when setting is enabled or not set
- Admin can modify and save the setting properly

## Database State
Confirmed the setting exists: display::icon_rotation | Disabled
