### PR TITLE
Refactor: Use Boolean for display_icon_rotation Throughout API

### DIFF
--- a/api/lib/control/profile.ts
+++ b/api/lib/control/profile.ts
@@ -50,10 +50,10 @@ export const DefaultUnits = Type.Object({
         options: Type.Array(Type.String())
     }),
     'icon_rotation': Type.Object({
-        value: Type.String({
-            default: 'Enabled'
+        value: Type.Boolean({
+            default: true
         }),
-        options: Type.Array(Type.String())
+        options: Type.Array(Type.Boolean())
     }),
 });
 
@@ -138,7 +138,7 @@ export default class ProfileControl {
             },
             icon_rotation: {
                 value: final.icon_rotation === 'false' ? false : true,
-                options: ['Enabled', 'Disabled']
+                options: [true, false]
             }
         }
     }

--- a/api/lib/enums.ts
+++ b/api/lib/enums.ts
@@ -125,7 +125,3 @@ export enum Profile_Elevation {
     FEET = 'feet'
 }
 
-export enum Profile_IconRotation {
-    ENABLED = 'Enabled',
-    DISABLED = 'Disabled'
-}

--- a/api/lib/types.ts
+++ b/api/lib/types.ts
@@ -141,7 +141,7 @@ export const ProfileResponse = Type.Object({
     tak_loc_freq: Type.Integer(),
     display_projection: Type.Enum(Profile_Projection),
     display_zoom: Type.Enum(Profile_Zoom),
-    display_icon_rotation: Type.String(),
+    display_icon_rotation: Type.Boolean(),
     display_stale: Type.Enum(Profile_Stale),
     display_text: Type.Enum(Profile_Text),
     display_distance: Type.Enum(Profile_Distance),

--- a/api/routes/profile.ts
+++ b/api/routes/profile.ts
@@ -22,8 +22,7 @@ export default async function router(schema: Schema, config: Config) {
             // @ts-expect-error Update Batch-Generic to specify actual geometry type (Point) instead of Geometry
             res.json({
                 active: config.wsClients.has(profile.username),
-                ...profile,
-                display_icon_rotation: profile.display_icon_rotation ? 'Enabled' : 'Disabled'
+                ...profile
             });
         } catch (err) {
              Err.respond(err, res);
@@ -41,7 +40,7 @@ export default async function router(schema: Schema, config: Config) {
             display_projection: Type.Optional(Type.Enum(Profile_Projection)),
             display_speed: Type.Optional(Type.Enum(Profile_Speed)),
             display_zoom: Type.Optional(Type.Enum(Profile_Zoom)),
-            display_icon_rotation: Type.Optional(Type.String()),
+            display_icon_rotation: Type.Optional(Type.Boolean()),
             display_text: Type.Optional(Type.Enum(Profile_Text)),
             tak_callsign: Type.Optional(Type.String()),
             tak_remarks: Type.Optional(Type.String()),
@@ -60,19 +59,13 @@ export default async function router(schema: Schema, config: Config) {
             const user = await Auth.as_user(config, req);
             
             const updateData: any = { ...req.body, updated: sql`Now()` };
-            
-            // Convert string to boolean for database storage
-            if (updateData.display_icon_rotation !== undefined) {
-                updateData.display_icon_rotation = updateData.display_icon_rotation === 'Enabled';
-            }
                         
             const profile = await config.models.Profile.commit(user.email, updateData);
 
             // @ts-expect-error Update Batch-Generic to specify actual geometry type (Point) instead of Geometry
             res.json({
                 active: config.wsClients.has(profile.username),
-                ...profile,
-                display_icon_rotation: profile.display_icon_rotation ? 'Enabled' : 'Disabled'
+                ...profile
             });
         } catch (err) {
              Err.respond(err, res);

--- a/api/test/profile.srv.test.ts
+++ b/api/test/profile.srv.test.ts
@@ -40,7 +40,7 @@ test('GET: api/profile', async (t) => {
             display_speed: 'mi/h',
             display_projection: 'globe',
             display_zoom: 'conditional',
-            display_icon_rotation: 'Enabled',
+            display_icon_rotation: true,
             display_text: 'Medium',
             system_admin: true,
             agency_admin: []


### PR DESCRIPTION
## Overview
Standardizes the `display_icon_rotation` field to use boolean values consistently across the entire API instead of string values ('Enabled'/'Disabled').

## Changes Made

### API Contract
- **Profile API**: Changed from string ('Enabled'/'Disabled') to boolean (true/false)
- **Admin Config API**: Updated to handle boolean values directly
- **Type Definitions**: Updated ProfileResponse to use boolean type

### Backend Changes
- **Profile Routes**: Removed string-to-boolean conversion logic
- **ProfileControl**: Updated DefaultUnits to return boolean values
- **Enums**: Removed Profile_IconRotation enum (no longer needed)

### Database Schema
- **Column Type**: Uses boolean with default true (matches existing migration)
- **Data Consistency**: All user profiles now use boolean values

### Testing
- **Profile Tests**: Updated expectations to use boolean values
- **API Contract**: Verified boolean values in response

## Benefits
- **Consistency**: Single data type throughout the stack
- **Simplicity**: No conversion logic needed
- **Type Safety**: Better TypeScript support with boolean type
- **Performance**: Eliminates string comparisons and conversions

## Migration Impact
- **Database**: No schema changes needed (already boolean)
- **Frontend**: Will receive boolean instead of string values
- **Backward Compatibility**: Breaking change - frontend must handle boolean values

## Testing
- ✅ Profile API returns boolean values
- ✅ Admin config displays boolean settings correctly  
- ✅ User preferences save and load as boolean
- ✅ All tests pass with boolean expectations
