### PR TITLE
Fix: Remove Profile_IconRotation Enum Import Causing Runtime Error

### DIFF
--- a/api/routes/config.ts
+++ b/api/routes/config.ts
@@ -5,7 +5,7 @@ import ProfileControl, { DefaultUnits } from '../lib/control/profile.js';
 import Err from '@openaddresses/batch-error';
 import Auth from '../lib/auth.js';
 import {
-    Profile_Stale, Profile_Speed, Profile_Elevation, Profile_Distance, Profile_Text, Profile_Projection, Profile_Zoom, Profile_IconRotation,
+    Profile_Stale, Profile_Speed, Profile_Elevation, Profile_Distance, Profile_Text, Profile_Projection, Profile_Zoom,
 } from '../lib/enums.js'
 import Config from '../lib/config.js';
 
@@ -80,7 +80,7 @@ export default async function router(schema: Schema, config: Config) {
             'display::projection': Type.Optional(Type.Enum(Profile_Projection)),
             'display::zoom': Type.Optional(Type.Enum(Profile_Zoom)),
             'display::text': Type.Optional(Type.Enum(Profile_Text)),
-            'display::icon_rotation': Type.Optional(Type.Enum(Profile_IconRotation)),
+            'display::icon_rotation': Type.Optional(Type.Boolean()),
 
             'group::Yellow': Type.Optional(Type.String()),
             'group::Cyan': Type.Optional(Type.String()),


### PR DESCRIPTION
## Problem
Application was crashing on startup with SyntaxError about missing Profile_IconRotation export.

## Root Cause
The Profile_IconRotation enum was removed in the refactor but the import statement in config.ts was not updated, causing a module import error.

## Solution
- Removed Profile_IconRotation from enum imports
- Changed Type.Enum(Profile_IconRotation) to Type.Boolean()

## Testing
- Application starts without import errors
- Config API accepts boolean values for icon rotation
- Admin config can save boolean settings
