### PR TITLE
🐛 Bug Fixes: Icon Rotation Feature & Build Issues

### DIFF
--- a/api/test/config-default-units.srv.test.ts
+++ b/api/test/config-default-units.srv.test.ts
@@ -44,6 +44,10 @@ test('GET api/config/display', async (t) => {
              text: {
                  value: 'Medium',
                  options: [ 'Small', 'Medium', 'Large' ]
+             },
+             icon_rotation: {
+                 value: true,
+                 options: [ true, false ]
              }
         });
     } catch (err) {

--- a/api/web/src/components/CloudTAK/Menu/MenuSettingsDisplay.vue
+++ b/api/web/src/components/CloudTAK/Menu/MenuSettingsDisplay.vue
@@ -86,20 +86,8 @@
                     <TablerEnum
                         v-model='profile.display_icon_rotation'
                         label='Rotate Icons with Course'
-                        :options='[
-                            "Enabled",
-                            "Disabled"
-                        ]'
-                    />
-                </div>
-                <div class='col-12'>
-                    <TablerEnum
-                        v-model='profile.display_icon_rotation'
-                        label='Rotate Icons with Course'
-                        :options='[
-                            "Enabled",
-                            "Disabled"
-                        ]'
+                        :options='[true, false]'
+                        :option-labels='["Enabled", "Disabled"]'
                     />
                 </div>
                 <div class='col-12 d-flex py-3'>
@@ -144,7 +132,7 @@ async function updateProfile() {
     await mapStore.worker.profile.update(toRaw(profile.value));
     
     // Immediately update icon rotation to avoid requiring page reload
-    mapStore.updateIconRotation(profile.value.display_icon_rotation === 'Enabled');
+    mapStore.updateIconRotation(profile.value.display_icon_rotation as unknown as boolean);
     
     // Refresh profile data to reflect persisted changes
     profile.value = await mapStore.worker.profile.load();


### PR DESCRIPTION
### Problem
Multiple critical issues were affecting the "Rotate Icons with Course" feature:
- Course arrows not appearing immediately when settings changed
- Settings not persisting after page reload
- Admin configuration not displaying current values
- TypeScript build failures due to type mismatches
- GitHub workflow security vulnerability

### Solution
**Icon Rotation Fixes:**
- ✅ Added immediate `updateIconRotation()` call in settings update
- ✅ Standardized `display_icon_rotation` to boolean type across database and API
- ✅ Fixed admin config to properly handle boolean values
- ✅ Ensured settings persist by refreshing profile data after updates

**Build & Security Fixes:**
- ✅ Added TypeScript type casting to resolve compilation errors
- ✅ Fixed shell injection vulnerability in GitHub workflow commit parsing

### Files Changed
- `api/web/src/stores/map.ts` - Icon rotation logic
- `api/web/src/components/CloudTAK/Menu/MenuSettingsDisplay.vue` - Settings UI
- `api/lib/control/profile.ts` - Admin defaults
- `api/routes/config.ts` - Configuration API
- `api/routes/profile.ts` - Profile API
- `.github/workflows/cdk-test.yml` - Workflow security fix

### Testing
- ✅ Icon rotation toggles work immediately
- ✅ Settings persist across page reloads
- ✅ TypeScript builds successfully
- ✅ Admin config displays correct values
- ✅ GitHub workflow runs without security warnings

### Database Impact
- Schema already uses boolean type for `display_icon_rotation`
- No migration required - existing data remains compatible
