### PR TITLE
Fix: Allow non-admin users to read config values

### DIFF
--- a/api/routes/config.ts
+++ b/api/routes/config.ts
@@ -22,7 +22,7 @@ export default async function router(schema: Schema, config: Config) {
         res: Type.Record(Type.String(), Type.Any())
     }, async (req, res) => {
         try {
-            await Auth.as_user(config, req, { admin: true });
+            await Auth.as_user(config, req);
 
             const final: Record<string, string> = {};
             (await Promise.allSettled((req.query.keys.split(',').map((key) => {


### PR DESCRIPTION
## Problem
Non-admin users were receiving `401 Unauthorized` errors when accessing `/api/config?keys=agol::enabled`, even though they were properly authenticated and could access other parts of the application.

## Root Cause
The GET `/config` endpoint required admin privileges (`{ admin: true }`), preventing regular authenticated users from reading configuration values.

## Solution
- Removed admin requirement from GET `/config` endpoint
- Maintained admin-only access for PUT `/config` (updates)
- Aligns with other read-only config endpoints like `/config/display`, `/config/group`, and `/config/map`

## Security Model
- **Read access**: All authenticated users can read config values
- **Write access**: Only admins can modify config values

## Testing
Verify that non-admin authenticated users can now successfully access:
```
GET /api/config?keys=agol::enabled
```