### PR TITLE
Fix Course Arrow Distance Logic for COT Types

### DIFF
--- a/api/web/src/base/utils/styles.ts
+++ b/api/web/src/base/utils/styles.ts
@@ -185,20 +185,20 @@ export default function styles(id: string, opts: {
                     8, [
                         'case',
                         ['has', 'group'],
-                        ['literal', [0, -28]],
-                        ['literal', [0, -18]]
+                        ['literal', [0, -18]],
+                        ['literal', [0, -28]]
                     ],
                     12, [
                         'case',
                         ['has', 'group'],
-                        ['literal', [0, -42]],
-                        ['literal', [0, -26]]
+                        ['literal', [0, -26]],
+                        ['literal', [0, -42]]
                     ],
                     16, [
                         'case',
                         ['has', 'group'],
-                        ['literal', [0, -58]],
-                        ['literal', [0, -34]]
+                        ['literal', [0, -34]],
+                        ['literal', [0, -58]]
                     ]
                 ],
                 'icon-rotate': ['get', 'course'],


### PR DESCRIPTION
## Problem
Course arrow positioning was inverted - grouped COT (regular icons) had larger distances while non-grouped COT (small dots) had smaller distances, causing poor visual alignment.

## Solution
Corrected the conditional logic to properly position course arrows:
- **Regular COT** (has `group` property): Reduced to 18/26/34px for better alignment with larger icons
- **User COT** (no `group` property): Maintains 28/42/58px distance for visibility with small dots

## Technical Details
- Fixed `icon-offset` conditional in course layer styling
- Uses MapLibre GL JS `case` expression to check for `group` property
- Maintains zoom-level interpolation for smooth scaling

## Files Changed
- `api/web/src/base/utils/styles.ts`

## Testing
- [x] Regular COT course arrows positioned correctly relative to icons
- [x] User COT course arrows maintain appropriate distance from dots
- [x] Both arrow types display at correct zoom levels
