### PR TITLE
CDK upgrade

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -98,6 +98,53 @@ jobs:
             echo "db-context=--context instanceClass=db.serverless --context instanceCount=1 --context enablePerformanceInsights=false --context monitoringInterval=0 --context backupRetentionDays=7 --context deleteProtection=false" >> $GITHUB_OUTPUT
           fi
 
+      # One-time migration: API Gateway v1 (REST) → v2 (HTTP API) for PMTiles
+      # The v1 and v2 domain names share the same namespace, so CloudFormation
+      # cannot create the v2 domain while the v1 domain still exists.
+      # This step detects the v1 domain and runs a skip-domain deploy first.
+      # Once the migration is complete, this step becomes a no-op automatically.
+      - name: Check PMTiles API GW Migration Needed (v1 → v2)
+        id: pmtiles-migration
+        run: |
+          V1_DOMAIN=$(aws apigateway get-domain-names \
+            --region ${{ vars.DEMO_AWS_REGION }} \
+            --query "items[?contains(domainName,'tiles')].domainName" \
+            --output text 2>/dev/null || true)
+          if [ -n "$V1_DOMAIN" ]; then
+            echo "needs-migration=true" >> $GITHUB_OUTPUT
+            echo "⚠️  V1 PMTiles domain found ($V1_DOMAIN) — two-step migration required"
+          else
+            echo "needs-migration=false" >> $GITHUB_OUTPUT
+            echo "✅ No V1 PMTiles domain — skipping migration"
+          fi
+
+      - name: PMTiles Migration Step 1 — Remove v1 domain from stack
+        if: steps.pmtiles-migration.outputs.needs-migration == 'true'
+        run: |
+          # Delete any orphaned v2 domain left over from a previous failed attempt
+          ORPHAN=$(aws apigatewayv2 get-domain-names \
+            --region ${{ vars.DEMO_AWS_REGION }} \
+            --query "Items[?contains(DomainName,'tiles')].DomainName" \
+            --output text 2>/dev/null || true)
+          if [ -n "$ORPHAN" ]; then
+            echo "Deleting orphaned v2 domain: $ORPHAN"
+            aws apigatewayv2 delete-domain-name \
+              --domain-name "$ORPHAN" \
+              --region ${{ vars.DEMO_AWS_REGION }}
+          fi
+          # Deploy with skipPmtilesDomain=true so CloudFormation deletes the v1
+          # RestApi + DomainName without simultaneously trying to create the v2 one
+          cd cdk
+          npm run cdk deploy -- \
+            --context envType=prod \
+            --context stackName=${{ vars.DEMO_STACK_NAME }} \
+            --context usePreBuiltImages=true \
+            --context cloudtakImageTag=${{ steps.images.outputs.cloudtak-tag }} \
+            --context useS3CloudTAKConfigFile=false \
+            ${{ steps.db-config.outputs.db-context }} \
+            --context skipPmtilesDomain=true \
+            --require-approval never
+
       - name: Deploy Demo with Prod Profile
         run: |
           cd cdk

--- a/UPSTREAM-CDK-CHANGES.md
+++ b/UPSTREAM-CDK-CHANGES.md
@@ -8,7 +8,54 @@ Reference diff: `git diff v12.47.2 v13.26.0 -- cloudformation/`
 
 ---
 
+## Audit Status
+
+_Last audited against CDK codebase on 2026-06-30._
+
+| # | Change | Priority | Breaking | CDK Status |
+|---|--------|----------|----------|------------|
+| 1 | IAM S3 least-privilege | High | No | ⚠️ Partial |
+| 2 | `cloudformation:ListStacks` | High | No | ❌ Missing |
+| 3 | EventBridge tag permissions | High | No | ❌ Missing |
+| 4 | GeofenceSecret + env var | High | No | ⚠️ Partial |
+| 5 | ECS service name | Low | **Yes** | ✅ Done |
+| 6 | KMS key rotation | Medium | No | ⬜ Out of scope (base-infra) |
+| 7 | S3 encryption + public access block | Medium | No | ✅ Done |
+| 8 | RDS security group IPv6 | Low | No | ❌ Missing |
+| 9 | PMTiles API GW v1 → v2 | High | **Yes** | ❌ Not done |
+| 10 | Lambda Node 20 → 24 | Medium | No | ❌ Missing |
+| 11 | Events auto-scaling + fixed CPU/mem | Medium | No | ❌ Missing |
+| 12 | Retention service (new) | Medium | No | ❌ Missing |
+| 13 | Webhooks API GW v1 → v2 | Conditional | **Yes** | ✅ Done |
+
+### Status key
+
+- ✅ **Done** — already implemented in the CDK codebase, no action required
+- ⚠️ **Partial** — partially implemented; remaining gaps noted in each section
+- ❌ **Missing / Not done** — not yet implemented
+- ⬜ **Out of scope** — the resource is owned by another stack (e.g. base-infra); needs action there
+
+### Suggested implementation order
+
+1. **Changes 2, 3, 8, 10** — all low-effort, non-breaking, do together in one PR
+2. **Changes 1 & 4** — S3 tightening + GeofenceSecret wiring, one PR
+3. **Change 11** — Events auto-scaling, one PR
+4. **Change 9** — PMTiles v1→v2 (plan a maintenance window), one PR
+5. **Change 12** — Retention service, one PR
+6. **Change 6** — Raise with base-infra maintainers to enable KMS key rotation
+
+---
+
 ## 1. IAM: Tighten S3 permissions on API and Events task roles
+
+> **CDK Status: ⚠️ Partial**
+>
+> `cloudtak-api.ts`: Already uses specific actions (`s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`,
+> `s3:ListBucket`, `s3:GetBucketLocation`) — not a wildcard. However `s3:AbortMultipartUpload` and
+> `s3:ListMultipartUploadParts` are missing, and the bucket-level / object-level actions are not
+> split into separate statements.
+>
+> `events-service.ts`: Still uses `actions: ['s3:*']` — **needs to be replaced**.
 
 **Source file:** `cloudformation/lib/api.js`, `cloudformation/lib/events.js`  
 **Priority:** High (security)  
@@ -55,11 +102,31 @@ new iam.PolicyStatement({
 }),
 ```
 
-For the Events task role, omit `s3:ListBucket` (object-level actions only).
+For the Events task role, replace `s3:*` with the object-level actions only (omit `s3:ListBucket`):
+
+```typescript
+new iam.PolicyStatement({
+    effect: iam.Effect.ALLOW,
+    actions: [
+        's3:GetObject',
+        's3:PutObject',
+        's3:DeleteObject',
+        's3:AbortMultipartUpload',
+        's3:ListMultipartUploadParts',
+    ],
+    resources: [`arn:aws:s3:::${assetBucketName}/*`],
+}),
+```
 
 ---
 
 ## 2. IAM: Add `cloudformation:ListStacks` to API task role
+
+> **CDK Status: ❌ Missing**
+>
+> `cloudtak-api.ts` has `cloudformation:DescribeStacks`, `ListExports`, `CreateStack`, etc., but
+> `cloudformation:ListStacks` is absent. All existing CloudFormation actions are scoped to specific
+> stack ARNs; `ListStacks` requires `Resource: *`.
 
 **Source file:** `cloudformation/lib/api.js`  
 **Priority:** High (functional — layer stack management broken without this)  
@@ -79,7 +146,7 @@ Added a new IAM statement to the API task role:
 
 ### How to implement in CDK
 
-Add a `PolicyStatement` to the API task role:
+Add a `PolicyStatement` to the API task role in `cdk/lib/constructs/cloudtak-api.ts`:
 
 ```typescript
 new iam.PolicyStatement({
@@ -92,6 +159,12 @@ new iam.PolicyStatement({
 ---
 
 ## 3. IAM: EventBridge tag permissions on API task role
+
+> **CDK Status: ❌ Missing**
+>
+> `cloudtak-api.ts` EventBridge statement has `events:PutRule`, `events:PutTargets`,
+> `events:DeleteRule`, `events:RemoveTargets`, `events:DescribeRule`. The three tag-management
+> actions (`UntagResource`, `TagResource`, `ListTagsForResource`) are not present.
 
 **Source file:** `cloudformation/lib/api.js`  
 **Priority:** High (functional — EventBridge rule management incomplete without these)  
@@ -107,12 +180,39 @@ Three new EventBridge actions added to the existing EventBridge policy block:
 
 ### How to implement in CDK
 
-Find the existing EventBridge policy statement on the API task role and add the three new actions
-alongside the existing ones (`events:PutRule`, `events:DescribeRule`, etc.).
+Find the existing EventBridge policy statement on the API task role in `cdk/lib/constructs/cloudtak-api.ts`
+and add the three new actions alongside the existing ones:
+
+```typescript
+new cdk.aws_iam.PolicyStatement({
+    effect: cdk.aws_iam.Effect.ALLOW,
+    actions: [
+        'events:PutRule',
+        'events:PutTargets',
+        'events:DeleteRule',
+        'events:RemoveTargets',
+        'events:DescribeRule',
+        'events:UntagResource',       // ← add
+        'events:TagResource',         // ← add
+        'events:ListTagsForResource', // ← add
+    ],
+    resources: [`arn:...rule/TAK-${envConfig.stackName}-CloudTAK-layer-*`]
+}),
+```
 
 ---
 
 ## 4. ECS: GeofenceSecret — new secret + env var
+
+> **CDK Status: ⚠️ Partial**
+>
+> `cdk/lib/constructs/secrets.ts`: `GeofenceSecret` **is** created with the correct name
+> (`TAK-${envConfig.stackName}-CloudTAK/api/geofence`). ✅
+>
+> `cdk/lib/cloudtak-stack.ts`: `secrets.geofenceSecret` is **not** passed to `CloudTakApi` props. ❌
+>
+> `cdk/lib/constructs/cloudtak-api.ts`: No `CLOUDTAK_Config_geofence_password` env var injected
+> into the API container, and no `grantRead` call on the secret. ❌
 
 **Source file:** `cloudformation/lib/api.js`  
 **Priority:** High (functional — geofence feature broken without this)  
@@ -129,46 +229,45 @@ alongside the existing ones (`events:PutRule`, `events:DescribeRule`, etc.).
 
 ### How to implement in CDK
 
-**Step 1** — Create the secret in `cdk/lib/cloudtak-stack.ts` (or wherever `SigningSecret` is created):
+The secret already exists. The remaining work is three steps:
+
+**Step 1** — Add `geofenceSecret` to `CloudTakApiProps` in `cloudtak-api.ts` and pass it from
+`cloudtak-stack.ts`:
 
 ```typescript
-const geofenceSecret = new secretsmanager.Secret(this, 'GeofenceSecret', {
-    secretName: `${stackName}/api/geofence`,
-    description: 'CloudTAK geofence service password',
-    generateSecretString: {
-        passwordLength: 32,
-        excludePunctuation: true,
-    },
-});
+// In CloudTakApiProps interface:
+geofenceSecret: secretsmanager.ISecret;
+
+// In cloudtak-stack.ts CloudTakApi constructor call:
+geofenceSecret: secrets.geofenceSecret,
 ```
 
-**Step 2** — Add it to the task definition dependency (if using L1 `CfnTaskDefinition`, add
-`addDependency(geofenceSecret)`; with L2, CDK handles ordering automatically when you use
-`ecs.Secret.fromSecretsManager()`).
-
-**Step 3** — Inject as an environment variable on the API container:
+**Step 2** — Grant read access and inject env var in `cloudtak-api.ts`:
 
 ```typescript
-environment: {
-    // existing vars …
-    CLOUDTAK_Config_geofence_password: secretsmanager.Secret
-        .fromSecretNameV2(this, 'GeofenceSecretRef', `${stackName}/api/geofence`)
-        .secretValue.unsafeUnwrap(),
-},
+// Grant access (alongside other secret grants)
+props.geofenceSecret.grantRead(executionRole);
+
+// In the container environment secrets map:
+secrets: {
+    'SigningSecret': ecs.Secret.fromSecretsManager(signingSecret),
+    'POSTGRES': ecs.Secret.fromSecretsManager(connectionStringSecret),
+    'CLOUDTAK_Config_geofence_password': ecs.Secret.fromSecretsManager(props.geofenceSecret), // ← add
+    // ...
+}
 ```
 
-Or, safer — use the resolve syntax directly in the environment map if you're using L1 constructs:
-
-```typescript
-{ name: 'CLOUDTAK_Config_geofence_password',
-  value: `{{resolve:secretsmanager:${stackName}/api/geofence}}` }
-```
-
-**Step 4** — Grant the API task role `secretsmanager:GetSecretValue` on the new secret.
+**Step 3** — CDK handles dependency ordering automatically when you use `ecs.Secret.fromSecretsManager()`,
+so no explicit `addDependency` call is needed.
 
 ---
 
 ## 5. ECS: Service name change
+
+> **CDK Status: ✅ Done**
+>
+> `cloudtak-api.ts` already uses `serviceName: \`TAK-${envConfig.stackName}-CloudTAK\`` — no
+> `-Service` suffix. This is consistent with the upstream change direction. No action required.
 
 **Source file:** `cloudformation/lib/api.js`  
 **Priority:** Low — **implement with caution**  
@@ -183,27 +282,24 @@ Or, safer — use the resolve syntax directly in the environment map if you're u
 
 ### How to implement in CDK
 
-Find the `serviceName` property on the CloudTAK API ECS Service construct and remove the `-Service`
-suffix.
+Already done. For reference, the CDK service name is set in `cdk/lib/constructs/cloudtak-api.ts`:
 
-**Before deploying**, verify whether the live service currently has the old name:
-
-```bash
-aws ecs describe-services \
-  --cluster TAK-Demo-BaseInfra \
-  --services TAK-Demo-CloudTAK-Service \
-  --region ap-southeast-2 \
-  --profile tak-nz-demo \
-  --query 'services[0].serviceName'
+```typescript
+this.service = new ecs.FargateService(this, 'Service', {
+    serviceName: `TAK-${envConfig.stackName}-CloudTAK`, // ← already correct
+    // ...
+});
 ```
-
-Because ECS service names are immutable, CloudFormation/CDK will **delete** the old service and
-**create** a new one. Plan for a rolling deployment window. Ensure the load balancer health check
-grace period is sufficient so the new service registers before the old one is fully drained.
 
 ---
 
 ## 6. KMS: Enable annual key rotation
+
+> **CDK Status: ⬜ Out of scope (base-infra)**
+>
+> The CloudTAK CDK stack does not own the KMS key — it imports it via
+> `kms.Key.fromKeyArn(...)` from a `base-infra` export. The `enableKeyRotation` property
+> can only be set on a key you own. **This change must be made in the base-infra stack.**
 
 **Source file:** `cloudformation/lib/kms.js`  
 **Priority:** Medium (security best practice)  
@@ -216,11 +312,13 @@ grace period is sufficient so the new service registers before the old one is fu
 + EnableKeyRotation: true
 ```
 
-### How to implement in CDK
+### How to implement
 
-Find the KMS key construct in the CDK stack and set `enableKeyRotation: true`:
+Find the KMS key construct in the **base-infra** CDK/CloudFormation stack and set
+`enableKeyRotation: true` (or `EnableKeyRotation: true`):
 
 ```typescript
+// In base-infra stack:
 const kmsKey = new kms.Key(this, 'KMS', {
     enableKeyRotation: true,  // ← add/change this
     description: stackName,
@@ -235,6 +333,12 @@ changes required.
 
 ## 7. S3: Public access block and AES256 encryption on asset bucket
 
+> **CDK Status: ✅ Done**
+>
+> `cdk/lib/constructs/s3-resources.ts` already sets `blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL`
+> and `encryption: s3.BucketEncryption.KMS` (which is stronger than upstream's AES256). No action
+> required. Consider adding `enforceSSL: true` as an optional hardening step.
+
 **Source file:** `cloudformation/lib/s3.js`  
 **Priority:** Medium (security hardening)  
 **Breaking:** No
@@ -246,21 +350,27 @@ to the asset bucket definition.
 
 ### How to implement in CDK
 
-The CDK L2 `s3.Bucket` construct applies these by default. Verify the existing bucket construct
-has these set (or relies on CDK defaults) and add them explicitly if not:
+Already done. For reference, `s3-resources.ts` has:
 
 ```typescript
 const assetBucket = new s3.Bucket(this, 'AssetBucket', {
-    bucketName: `${stackName}-${this.account}-${this.region}`,
-    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,  // ← ensures all 4 settings
-    encryption: s3.BucketEncryption.S3_MANAGED,         // ← AES256
-    enforceSSL: true,                                    // ← recommended alongside encryption
+    encryption: s3.BucketEncryption.KMS,             // ✅ stronger than upstream AES256
+    encryptionKey: kmsKey,
+    blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL, // ✅ all 4 settings
+    // Optional hardening (not yet set):
+    // enforceSSL: true,
 });
 ```
 
 ---
 
 ## 8. RDS security group: Add IPv6 ingress rule
+
+> **CDK Status: ❌ Missing**
+>
+> `cdk/lib/constructs/security-groups.ts` imports `vpcCidrIpv6` and uses it for ECS outbound
+> rules, but the **database** security group only has one ingress rule:
+> `this.ecs → Port.tcp(5432)`. No IPv6 ingress rule exists on the database SG.
 
 **Source file:** `cloudformation/lib/db.js`  
 **Priority:** Low  
@@ -282,6 +392,21 @@ Added a second ingress rule to the RDS security group for IPv6:
 
 ### How to implement in CDK
 
+In `cdk/lib/constructs/security-groups.ts`, add a second ingress rule to `this.database`
+(the `vpcCidrIpv6` variable is already imported in that file):
+
+```typescript
+// Existing rule:
+this.database.addIngressRule(this.ecs, ec2.Port.tcp(5432), 'ECS to Database');
+
+// Add this:
+this.database.addIngressRule(
+    ec2.Peer.ipv6(vpcCidrIpv6),
+    ec2.Port.tcp(5432),
+    'Allow Internal IPv6 network access',
+);
+```
+
 **Pre-condition:** Verify that the base-infra stack exports `tak-vpc-${env}-vpc-cidr-ipv6`. If it
 does not export this value, skip this change.
 
@@ -292,21 +417,15 @@ aws cloudformation list-exports \
   --query "Exports[?contains(Name, 'ipv6')]"
 ```
 
-If the export exists, find the RDS security group in the CDK stack and add:
-
-```typescript
-dbSecurityGroup.addIngressRule(
-    ec2.Peer.ipv6(
-        Fn.importValue(`tak-vpc-${environment}-vpc-cidr-ipv6`)
-    ),
-    ec2.Port.tcp(5432),
-    'Allow Internal IPv6 network access',
-);
-```
-
 ---
 
 ## 9. PMTiles: Migrate from API Gateway v1 (REST) to v2 (HTTP API)
+
+> **CDK Status: ❌ Not done**
+>
+> `cdk/lib/constructs/lambda-functions.ts` still uses `apigateway.RestApi` (v1 REST API) with
+> `PMTilesApiGatewayRole`, `apigateway.DomainName`, `apigateway.Deployment`, `apigateway.Stage`,
+> and `apigateway.BasePathMapping`. The PMTiles Lambda also lacks the `API_URL` environment variable.
 
 **Source file:** `cloudformation/lib/pmtiles.js`  
 **Priority:** High (architecture — HTTP API is cheaper, simpler, and has built-in CORS)  
@@ -332,7 +451,7 @@ Also: `API_URL` env var added to the PMTiles Lambda.
 
 ### How to implement in CDK
 
-Find the PMTiles API Gateway construct in `cdk/lib/constructs/` or `cdk/lib/cloudtak-stack.ts`.
+Find the PMTiles API Gateway construct in `cdk/lib/constructs/lambda-functions.ts`.
 
 **Step 1** — Replace `apigw.RestApi` with `apigwv2.HttpApi`:
 
@@ -405,6 +524,11 @@ maintenance window.
 
 ## 10. Lambda: Bump EFS cleanup runtime to Node.js 24
 
+> **CDK Status: ❌ Missing**
+>
+> `cdk/lib/constructs/pmtiles-efs.ts` — `CleanupLambda` uses `lambda.Runtime.NODEJS_20_X`.
+> One-line change required.
+
 **Source file:** `cloudformation/lib/pmtiles.js`  
 **Priority:** Medium (Node 20 EOL approaching)  
 **Breaking:** No
@@ -418,10 +542,10 @@ maintenance window.
 
 ### How to implement in CDK
 
-Find the EFS cleanup Lambda in the PMTiles construct and update:
+In `cdk/lib/constructs/pmtiles-efs.ts`, update the cleanup Lambda runtime:
 
 ```typescript
-new lambda.Function(this, 'EFSCleanupLambda', {
+this.cleanupLambda = new lambda.Function(this, 'CleanupLambda', {
     runtime: lambda.Runtime.NODEJS_24_X,  // ← was NODEJS_20_X
     // …
 });
@@ -430,6 +554,12 @@ new lambda.Function(this, 'EFSCleanupLambda', {
 ---
 
 ## 11. ECS Events: Auto-scaling + dedicated CPU/memory
+
+> **CDK Status: ❌ Missing**
+>
+> `cdk/lib/constructs/events-service.ts` uses `envConfig.ecs.taskCpu` / `envConfig.ecs.taskMemory`
+> for the Events task definition (same shared config as the API service). It should use fixed values
+> of **1024 CPU / 2048 MB**. No auto-scaling is configured at all.
 
 **Source file:** `cloudformation/lib/events.js`  
 **Priority:** Medium (operational — prevents Events service saturation under load)  
@@ -447,12 +577,12 @@ new lambda.Function(this, 'EFSCleanupLambda', {
 
 ### How to implement in CDK
 
-**Step 1** — Fix the Events task definition CPU/memory:
+**Step 1** — Fix the Events task definition CPU/memory in `cdk/lib/constructs/events-service.ts`:
 
 ```typescript
 const eventsTaskDef = new ecs.FargateTaskDefinition(this, 'EventsTaskDefinition', {
-    cpu: 1024,
-    memoryLimitMiB: 2048,
+    cpu: 1024,           // ← was envConfig.ecs.taskCpu
+    memoryLimitMiB: 2048, // ← was envConfig.ecs.taskMemory
     // …
 });
 ```
@@ -467,14 +597,14 @@ const eventsScaling = eventsService.autoScaleTaskCount({
 
 eventsScaling.scaleOnCpuUtilization('EventsCPUScaling', {
     targetUtilizationPercent: 70,
-    scaleInCooldown: Duration.seconds(300),
-    scaleOutCooldown: Duration.seconds(60),
+    scaleInCooldown: cdk.Duration.seconds(300),
+    scaleOutCooldown: cdk.Duration.seconds(60),
 });
 
 eventsScaling.scaleOnMemoryUtilization('EventsMemoryScaling', {
     targetUtilizationPercent: 80,
-    scaleInCooldown: Duration.seconds(300),
-    scaleOutCooldown: Duration.seconds(60),
+    scaleInCooldown: cdk.Duration.seconds(300),
+    scaleOutCooldown: cdk.Duration.seconds(60),
 });
 ```
 
@@ -484,6 +614,11 @@ automatically — no need to create them manually.
 ---
 
 ## 12. New: Retention service (scheduled ECS task)
+
+> **CDK Status: ❌ Missing**
+>
+> No `RetentionService` construct exists in `cdk/lib/constructs/` and it is not referenced in
+> `cdk/lib/cloudtak-stack.ts`. This is a net-new component to be built.
 
 **Source file:** `cloudformation/lib/retention.js` (new file)  
 **Priority:** Medium (functional — old data cleanup does not run without this)  
@@ -567,7 +702,7 @@ import * as targets from 'aws-cdk-lib/aws-events-targets';
 
 const retentionSchedule = new events.Rule(this, 'RetentionSchedule', {
     description: 'Schedule for CloudTAK retention runs',
-    schedule: events.Schedule.rate(Duration.days(1)),
+    schedule: events.Schedule.rate(cdk.Duration.days(1)),
     enabled: true,
 });
 
@@ -586,6 +721,12 @@ retentionSchedule.addTarget(new targets.EcsTask({
 
 ## 13. Webhooks: API Gateway v1 → v2 domain name resource
 
+> **CDK Status: ✅ Done**
+>
+> `cdk/lib/constructs/webhooks.ts` already uses `apigatewayv2.CfnDomainName` with
+> `domainNameConfigurations: [{ certificateArn, endpointType: 'REGIONAL' }]` throughout.
+> No action required.
+
 **Source file:** `cloudformation/webhooks.template.js`  
 **Priority:** Depends on whether the webhooks stack is deployed  
 **Breaking:** ⚠️ YES — triggers replacement of the domain name resource
@@ -603,61 +744,16 @@ The webhooks API domain changed from `AWS::ApiGateway::DomainName` (v1) to
 + DomainNameConfigurations: [{ CertificateArn: …, EndpointType: 'REGIONAL' }]
 ```
 
-### How to implement in CDK
+### Current CDK implementation
 
-**Pre-condition:** Check whether the webhooks stack is deployed for your environment:
-
-```bash
-aws cloudformation describe-stacks \
-  --stack-name TAK-Demo-CloudTAK-Webhooks \
-  --region ap-southeast-2 \
-  --profile tak-nz-demo 2>&1 | grep StackStatus
-```
-
-If the webhooks stack is deployed, find the domain name construct and update it. The CDK L2
-`apigwv2.DomainName` construct already uses the v2 resource type:
+Already correct in `cdk/lib/constructs/webhooks.ts`:
 
 ```typescript
-// If using L1 CfnDomainName, replace with:
-import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
-
-const webhooksDomain = new apigwv2.DomainName(this, 'CloudTAKWebhooksApiDomain', {
-    domainName: `${subdomainPrefix}.${hostedZoneName}`,
-    certificate: acmCert,
-    endpointType: apigwv2.EndpointType.REGIONAL,
+this.domainName = new apigatewayv2.CfnDomainName(this, 'WebhooksDomain', {
+    domainName: this.webhookUrl,
+    domainNameConfigurations: [{
+        certificateArn: certificate.certificateArn,
+        endpointType: 'REGIONAL'
+    }]
 });
 ```
-
-**Deployment note:** Same caution as change #9 — the old v1 domain resource will be deleted and
-a new v2 resource created. Briefly, the subdomain DNS alias will be stale. Perform during a
-low-traffic window.
-
----
-
-## Summary
-
-| # | Change | Priority | Breaking | Effort |
-|---|--------|----------|----------|--------|
-| 1 | IAM S3 least-privilege | High | No | Low |
-| 2 | `cloudformation:ListStacks` | High | No | Low |
-| 3 | EventBridge tag permissions | High | No | Low |
-| 4 | GeofenceSecret + env var | High | No | Medium |
-| 5 | ECS service name | Low | **Yes** | Low |
-| 6 | KMS key rotation | Medium | No | Low |
-| 7 | S3 encryption + public access block | Medium | No | Low |
-| 8 | RDS security group IPv6 | Low | No | Low |
-| 9 | PMTiles API GW v1 → v2 | High | **Yes** | High |
-| 10 | Lambda Node 20 → 24 | Medium | No | Low |
-| 11 | Events auto-scaling + fixed CPU/mem | Medium | No | Medium |
-| 12 | Retention service (new) | Medium | No | High |
-| 13 | Webhooks API GW v1 → v2 | Conditional | **Yes** | Medium |
-
-**Suggested implementation order:**
-
-1. Changes 1–3, 6–8, 10 — low-effort, non-breaking, do together in one PR
-2. Change 4 (GeofenceSecret) — requires secret creation + migration, one PR
-3. Change 11 (Events auto-scaling) — one PR
-4. Change 9 (PMTiles v1→v2) — plan a maintenance window, one PR
-5. Change 12 (Retention service) — one PR
-6. Change 5 (service name) — plan a maintenance window, do last
-7. Change 13 (Webhooks) — only if webhooks stack is deployed

--- a/UPSTREAM-CDK-CHANGES.md
+++ b/UPSTREAM-CDK-CHANGES.md
@@ -10,39 +10,47 @@ Reference diff: `git diff v12.47.2 v13.26.0 -- cloudformation/`
 
 ## Audit Status
 
-_Last audited against CDK codebase on 2026-06-30._
+_Last audited against CDK codebase on 2026-06-30. All actionable items implemented in `feat/cdk-upstream-changes`._
 
 | # | Change | Priority | Breaking | CDK Status |
 |---|--------|----------|----------|------------|
-| 1 | IAM S3 least-privilege | High | No | ⚠️ Partial |
-| 2 | `cloudformation:ListStacks` | High | No | ❌ Missing |
-| 3 | EventBridge tag permissions | High | No | ❌ Missing |
-| 4 | GeofenceSecret + env var | High | No | ⚠️ Partial |
+| 1 | IAM S3 least-privilege | High | No | ✅ Done |
+| 2 | `cloudformation:ListStacks` | High | No | ✅ Done |
+| 3 | EventBridge tag permissions | High | No | ✅ Done |
+| 4 | GeofenceSecret + env var | High | No | ✅ Done |
 | 5 | ECS service name | Low | **Yes** | ✅ Done |
 | 6 | KMS key rotation | Medium | No | ⬜ Out of scope (base-infra) |
 | 7 | S3 encryption + public access block | Medium | No | ✅ Done |
-| 8 | RDS security group IPv6 | Low | No | ❌ Missing |
-| 9 | PMTiles API GW v1 → v2 | High | **Yes** | ❌ Not done |
-| 10 | Lambda Node 20 → 24 | Medium | No | ❌ Missing |
-| 11 | Events auto-scaling + fixed CPU/mem | Medium | No | ❌ Missing |
-| 12 | Retention service (new) | Medium | No | ❌ Missing |
+| 8 | RDS security group IPv6 | Low | No | ✅ Done |
+| 9 | PMTiles API GW v1 → v2 | High | **Yes** | ✅ Done |
+| 10 | Lambda Node 20 → 24 | Medium | No | ✅ Done |
+| 11 | Events auto-scaling + fixed CPU/mem | Medium | No | ✅ Done |
+| 12 | Retention service (new) | Medium | No | ✅ Done |
 | 13 | Webhooks API GW v1 → v2 | Conditional | **Yes** | ✅ Done |
 
 ### Status key
 
-- ✅ **Done** — already implemented in the CDK codebase, no action required
-- ⚠️ **Partial** — partially implemented; remaining gaps noted in each section
-- ❌ **Missing / Not done** — not yet implemented
-- ⬜ **Out of scope** — the resource is owned by another stack (e.g. base-infra); needs action there
+- ✅ **Done** — implemented in the CDK codebase
+- ⬜ **Out of scope** — the resource is owned by another stack (base-infra); needs action there
 
-### Suggested implementation order
+### PMTiles API GW migration note (#9)
 
-1. **Changes 2, 3, 8, 10** — all low-effort, non-breaking, do together in one PR
-2. **Changes 1 & 4** — S3 tightening + GeofenceSecret wiring, one PR
-3. **Change 11** — Events auto-scaling, one PR
-4. **Change 9** — PMTiles v1→v2 (plan a maintenance window), one PR
-5. **Change 12** — Retention service, one PR
-6. **Change 6** — Raise with base-infra maintainers to enable KMS key rotation
+The v1 → v2 migration requires a two-step deployment because both share the same domain namespace
+and CloudFormation creates before it deletes within a single changeset.
+
+**Manual deployment:**
+```bash
+# Step 1 — delete orphaned v2 domain (if any from a previous failed attempt), then deploy
+aws apigatewayv2 delete-domain-name --domain-name tiles.<hostname> --region <region>
+npm run cdk deploy -- ... --context skipPmtilesDomain=true --require-approval never
+
+# Step 2 — normal deploy creates the v2 domain
+npm run cdk deploy -- ... --require-approval never
+```
+
+**GitHub Actions (demo pipeline):** The `demo-deploy.yml` workflow auto-detects the v1 domain
+and runs the two-step migration automatically. Once migration is complete the detection step
+becomes a no-op on every subsequent pipeline run.
 
 ---
 

--- a/cdk/lib/cloudtak-stack.ts
+++ b/cdk/lib/cloudtak-stack.ts
@@ -38,6 +38,7 @@ import { Webhooks } from './constructs/webhooks';
 import { EtlRole } from './constructs/etl-role';
 import { CloudTakOidcSetup } from './constructs/cloudtak-oidc-setup';
 import { PMTilesEfs } from './constructs/pmtiles-efs';
+import { RetentionService } from './constructs/retention-service';
 
 import { registerOutputs } from './outputs';
 import { createBaseImportValue, BASE_EXPORT_NAMES } from './cloudformation-imports';
@@ -134,6 +135,7 @@ export class CloudTakStack extends cdk.Stack {
     let dockerImageAsset: ecrAssets.DockerImageAsset | undefined;
     let eventsImageAsset: ecrAssets.DockerImageAsset | undefined;
     let tilesImageAsset: ecrAssets.DockerImageAsset | undefined;
+    let retentionImageAsset: ecrAssets.DockerImageAsset | undefined;
     
     if (usePreBuiltImages) {
       // Use BaseInfra ECR repository for CI/CD deployments
@@ -189,6 +191,30 @@ export class CloudTakStack extends cdk.Stack {
       tilesImageAsset = new ecrAssets.DockerImageAsset(this, 'TilesDockerAsset', {
         directory: '..',
         file: 'tasks/pmtiles/Dockerfile',
+        buildArgs: {
+          NODE_ENV: environment === 'prod' ? 'production' : 'development'
+        },
+        exclude: [
+          'node_modules/**',
+          '**/node_modules/**',
+          '**/.git/**',
+          '**/.vscode/**',
+          '**/.idea/**',
+          '**/*.log',
+          '**/*.tmp',
+          '**/.DS_Store',
+          '**/Thumbs.db',
+          'cdk/**',
+          'api/dist/**',
+          'api/fonts/**',
+          'api/web/node_modules/**',
+          'api/web/dist/**',
+        ]
+      });
+
+      retentionImageAsset = new ecrAssets.DockerImageAsset(this, 'RetentionDockerAsset', {
+        directory: '..',
+        file: 'tasks/retention/Dockerfile',
         buildArgs: {
           NODE_ENV: environment === 'prod' ? 'production' : 'development'
         },
@@ -360,6 +386,7 @@ export class CloudTakStack extends cdk.Stack {
       assetBucketName: s3Resources.assetBucket.bucketName,
       signingSecret: secrets.signingSecret,
       adminPasswordSecret: secrets.adminPasswordSecret,
+      geofenceSecret: secrets.geofenceSecret,
       serviceUrl: route53Records.serviceUrl
     });
 
@@ -385,6 +412,19 @@ export class CloudTakStack extends cdk.Stack {
     const alarms = new Alarms(this, 'Alarms', {
       envConfig,
       eventsService: eventsService.service
+    });
+
+    // Create retention service for automated cleanup of expired data
+    new RetentionService(this, 'RetentionService', {
+      envConfig,
+      vpc,
+      ecsCluster,
+      ecrRepository,
+      retentionImageAsset,
+      assetBucketName: s3Resources.assetBucket.bucketName,
+      serviceUrl: route53Records.serviceUrl,
+      connectionStringSecret: database.connectionStringSecret,
+      kmsKey,
     });
 
     // Create webhooks infrastructure for layer webhook support

--- a/cdk/lib/constructs/cloudtak-api.ts
+++ b/cdk/lib/constructs/cloudtak-api.ts
@@ -41,6 +41,7 @@ export interface CloudTakApiProps {
   assetBucketName: string;
   signingSecret: secretsmanager.ISecret;
   adminPasswordSecret: secretsmanager.ISecret;
+  geofenceSecret: secretsmanager.ISecret;
   serviceUrl: string;
 }
 
@@ -68,6 +69,7 @@ export class CloudTakApi extends Construct {
       assetBucketName,
       signingSecret,
       adminPasswordSecret,
+      geofenceSecret,
       serviceUrl
     } = props;
 
@@ -97,11 +99,23 @@ export class CloudTakApi extends Construct {
               ],
               resources: ['*']
             }),
-            // S3 bucket access
+            // S3 bucket access — bucket level (list/locate only)
             new cdk.aws_iam.PolicyStatement({
               effect: cdk.aws_iam.Effect.ALLOW,
-              actions: ['s3:GetObject', 's3:PutObject', 's3:DeleteObject', 's3:ListBucket', 's3:GetBucketLocation'],
-              resources: [`arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}`, `arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}/*`]
+              actions: ['s3:ListBucket', 's3:GetBucketLocation'],
+              resources: [`arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}`]
+            }),
+            // S3 bucket access — object level
+            new cdk.aws_iam.PolicyStatement({
+              effect: cdk.aws_iam.Effect.ALLOW,
+              actions: [
+                's3:GetObject',
+                's3:PutObject',
+                's3:DeleteObject',
+                's3:AbortMultipartUpload',
+                's3:ListMultipartUploadParts',
+              ],
+              resources: [`arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}/*`]
             }),
 
             // SQS permissions for layer queues
@@ -137,6 +151,12 @@ export class CloudTakApi extends Construct {
                 `arn:${cdk.Stack.of(this).partition}:cloudformation:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:stack/TAK-${envConfig.stackName}-*`,
                 `arn:${cdk.Stack.of(this).partition}:cloudformation:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:stack/TAK-${envConfig.stackName}-layer-*`
               ]
+            }),
+            // cloudformation:ListStacks requires Resource: * (no ARN filtering possible)
+            new cdk.aws_iam.PolicyStatement({
+              effect: cdk.aws_iam.Effect.ALLOW,
+              actions: ['cloudformation:ListStacks'],
+              resources: ['*']
             }),
             // Batch job permissions
             new cdk.aws_iam.PolicyStatement({
@@ -222,7 +242,16 @@ export class CloudTakApi extends Construct {
             // EventBridge permissions for scheduled Lambda functions
             new cdk.aws_iam.PolicyStatement({
               effect: cdk.aws_iam.Effect.ALLOW,
-              actions: ['events:PutRule', 'events:PutTargets', 'events:DeleteRule', 'events:RemoveTargets', 'events:DescribeRule'],
+              actions: [
+                'events:PutRule',
+                'events:PutTargets',
+                'events:DeleteRule',
+                'events:RemoveTargets',
+                'events:DescribeRule',
+                'events:UntagResource',
+                'events:TagResource',
+                'events:ListTagsForResource',
+              ],
               resources: [`arn:${cdk.Stack.of(this).partition}:events:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:rule/TAK-${envConfig.stackName}-CloudTAK-layer-*`]
             }),
             // API Gateway permissions for webhook functionality
@@ -333,6 +362,7 @@ export class CloudTakApi extends Construct {
     takAdminCertSecret.grantRead(taskRole); // Task role for application access
     connectionStringSecret.grantRead(executionRole);
     adminPasswordSecret.grantRead(executionRole);
+    geofenceSecret.grantRead(executionRole);
     
     // Grant access to Authentik admin secret if OIDC is enabled
     if (envConfig.cloudtak.oidcEnabled) {
@@ -404,7 +434,8 @@ export class CloudTakApi extends Construct {
         'SigningSecret': ecs.Secret.fromSecretsManager(signingSecret),
         'POSTGRES': ecs.Secret.fromSecretsManager(connectionStringSecret),
         'CLOUDTAK_ADMIN_USERNAME': ecs.Secret.fromSecretsManager(adminPasswordSecret, 'username'),
-        'CLOUDTAK_ADMIN_PASSWORD': ecs.Secret.fromSecretsManager(adminPasswordSecret, 'password')
+        'CLOUDTAK_ADMIN_PASSWORD': ecs.Secret.fromSecretsManager(adminPasswordSecret, 'password'),
+        'CLOUDTAK_Config_geofence_password': ecs.Secret.fromSecretsManager(geofenceSecret),
       }
     };
 

--- a/cdk/lib/constructs/events-service.ts
+++ b/cdk/lib/constructs/events-service.ts
@@ -62,9 +62,14 @@ export class EventsService extends Construct {
             }),
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
-              actions: ['s3:*'],
+              actions: [
+                's3:GetObject',
+                's3:PutObject',
+                's3:DeleteObject',
+                's3:AbortMultipartUpload',
+                's3:ListMultipartUploadParts',
+              ],
               resources: [
-                `arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}`,
                 `arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}/*`
               ]
             }),
@@ -108,11 +113,11 @@ export class EventsService extends Construct {
       }
     });
 
-    // Create task definition
+    // Create task definition — fixed 1024 CPU / 2048 MB per upstream change #11
     this.taskDefinition = new ecs.FargateTaskDefinition(this, 'EventsTaskDefinition', {
       family: `TAK-${envConfig.stackName}-CloudTAK-events`,
-      cpu: envConfig.ecs.taskCpu,
-      memoryLimitMiB: envConfig.ecs.taskMemory,
+      cpu: 1024,
+      memoryLimitMiB: 2048,
       taskRole: taskRole,
       executionRole: executionRole
     });
@@ -177,5 +182,23 @@ export class EventsService extends Construct {
 
     // Add tags
     cdk.Tags.of(this.service).add('Name', `TAK-${envConfig.stackName}-CloudTAK-events`);
+
+    // Auto-scaling: track CPU (70%) and memory (80%), scale between 1–10 tasks
+    const scaling = this.service.autoScaleTaskCount({
+      minCapacity: 1,
+      maxCapacity: 10,
+    });
+
+    scaling.scaleOnCpuUtilization('EventsCPUScaling', {
+      targetUtilizationPercent: 70,
+      scaleInCooldown: cdk.Duration.seconds(300),
+      scaleOutCooldown: cdk.Duration.seconds(60),
+    });
+
+    scaling.scaleOnMemoryUtilization('EventsMemoryScaling', {
+      targetUtilizationPercent: 80,
+      scaleInCooldown: cdk.Duration.seconds(300),
+      scaleOutCooldown: cdk.Duration.seconds(60),
+    });
   }
 }

--- a/cdk/lib/constructs/lambda-functions.ts
+++ b/cdk/lib/constructs/lambda-functions.ts
@@ -217,43 +217,54 @@ export class LambdaFunctions extends Construct {
       autoDeploy: true,
     });
 
-    // Custom domain mapped to the API
-    const pmtilesDomain = new apigwv2.CfnDomainName(this, 'PMTilesDomain', {
-      domainName: tilesHostname,
-      domainNameConfigurations: [
-        {
-          certificateArn: certificate.certificateArn,
-          endpointType: 'REGIONAL',
-        },
-      ],
-    });
+    // Two-step migration guard:
+    // When upgrading from API GW v1 → v2, the old v1 DomainName must be deleted
+    // by CloudFormation BEFORE the new v2 DomainName can be created (they share
+    // the same domain namespace).  Deploy once with --context skipPmtilesDomain=true
+    // to let CloudFormation remove the v1 resources, then redeploy without the flag
+    // to create the v2 domain and DNS records.
+    const skipDomain = cdk.Stack.of(this).node.tryGetContext('skipPmtilesDomain') === true
+      || cdk.Stack.of(this).node.tryGetContext('skipPmtilesDomain') === 'true';
 
-    new apigwv2.CfnApiMapping(this, 'PMTilesApiMapping', {
-      apiId: this.tilesApi.ref,
-      domainName: pmtilesDomain.ref,
-      stage: stage.ref,
-    });
+    if (!skipDomain) {
+      // Custom domain mapped to the API
+      const pmtilesDomain = new apigwv2.CfnDomainName(this, 'PMTilesDomain', {
+        domainName: tilesHostname,
+        domainNameConfigurations: [
+          {
+            certificateArn: certificate.certificateArn,
+            endpointType: 'REGIONAL',
+          },
+        ],
+      });
 
-    // Route53 — alias to the v2 regional domain name
-    const aliasTarget = route53.RecordTarget.fromAlias({
-      bind: () => ({
-        dnsName: pmtilesDomain.attrRegionalDomainName,
-        hostedZoneId: pmtilesDomain.attrRegionalHostedZoneId,
-      }),
-    });
+      new apigwv2.CfnApiMapping(this, 'PMTilesApiMapping', {
+        apiId: this.tilesApi.ref,
+        domainName: pmtilesDomain.ref,
+        stage: stage.ref,
+      });
 
-    new route53.ARecord(this, 'PMTilesDNS', {
-      zone: hostedZone,
-      recordName: `tiles.${envConfig.cloudtak.hostname}`,
-      target: aliasTarget,
-      comment: `${cdk.Stack.of(this).stackName} PMTiles API DNS Entry`,
-    });
+      // Route53 — alias to the v2 regional domain name
+      const aliasTarget = route53.RecordTarget.fromAlias({
+        bind: () => ({
+          dnsName: pmtilesDomain.attrRegionalDomainName,
+          hostedZoneId: pmtilesDomain.attrRegionalHostedZoneId,
+        }),
+      });
 
-    new route53.AaaaRecord(this, 'PMTilesDNSIPv6', {
-      zone: hostedZone,
-      recordName: `tiles.${envConfig.cloudtak.hostname}`,
-      target: aliasTarget,
-      comment: `${cdk.Stack.of(this).stackName} PMTiles API IPv6 DNS Entry`,
-    });
+      new route53.ARecord(this, 'PMTilesDNS', {
+        zone: hostedZone,
+        recordName: `tiles.${envConfig.cloudtak.hostname}`,
+        target: aliasTarget,
+        comment: `${cdk.Stack.of(this).stackName} PMTiles API DNS Entry`,
+      });
+
+      new route53.AaaaRecord(this, 'PMTilesDNSIPv6', {
+        zone: hostedZone,
+        recordName: `tiles.${envConfig.cloudtak.hostname}`,
+        target: aliasTarget,
+        comment: `${cdk.Stack.of(this).stackName} PMTiles API IPv6 DNS Entry`,
+      });
+    }
   }
 }

--- a/cdk/lib/constructs/lambda-functions.ts
+++ b/cdk/lib/constructs/lambda-functions.ts
@@ -1,3 +1,15 @@
+/**
+ * Lambda Functions construct — PMTiles tile server
+ *
+ * Change #9: migrated from API Gateway v1 (REST API) to v2 (HTTP API).
+ * HTTP API is cheaper, natively handles CORS, and uses a resource-based Lambda
+ * permission instead of an execution-role credential.
+ *
+ * Deployment note: the first deploy that removes the v1 resources and creates the
+ * v2 resources will cause a brief DNS gap on tiles.<domain>.  Schedule during a
+ * low-traffic window.
+ */
+
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
@@ -5,9 +17,8 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as ecrAssets from 'aws-cdk-lib/aws-ecr-assets';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
-import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as route53 from 'aws-cdk-lib/aws-route53';
-import * as route53targets from 'aws-cdk-lib/aws-route53-targets';
 import * as efs from 'aws-cdk-lib/aws-efs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { ContextEnvironmentConfig } from '../stack-config';
@@ -29,69 +40,97 @@ export interface LambdaFunctionsProps {
 
 export class LambdaFunctions extends Construct {
   public readonly tilesLambda: lambda.Function;
-  public readonly tilesApi: apigateway.RestApi;
+  public readonly tilesApi: apigwv2.CfnApi;
 
   constructor(scope: Construct, id: string, props: LambdaFunctionsProps) {
     super(scope, id);
 
-    const { envConfig, ecrRepository, tilesImageAsset, assetBucketName, serviceUrl, signingSecret, kmsKey, hostedZone, certificate, vpc, efsAccessPoint, lambdaSecurityGroup } = props;
+    const {
+      envConfig,
+      ecrRepository,
+      tilesImageAsset,
+      assetBucketName,
+      serviceUrl,
+      signingSecret,
+      kmsKey,
+      hostedZone,
+      certificate,
+      vpc,
+      efsAccessPoint,
+      lambdaSecurityGroup,
+    } = props;
 
-    // Get image tag from context for CI/CD deployments
-    const cloudtakImageTag = cdk.Stack.of(this).node.tryGetContext('cloudtakImageTag');
+    const cloudtakImageTag =
+      cdk.Stack.of(this).node.tryGetContext('cloudtakImageTag');
 
-    
-    // Create PMTiles Lambda Role
+    // IAM role for the PMTiles Lambda
     const tilesLambdaRole = new iam.Role(this, 'PMTilesLambdaRole', {
       roleName: `TAK-${envConfig.stackName}-CloudTAK-pmtiles`,
       assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
       inlinePolicies: {
-        'pmtiles': new iam.PolicyDocument({
+        pmtiles: new iam.PolicyDocument({
           statements: [
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
               actions: ['s3:List*', 's3:Get*', 's3:Head*', 's3:Describe*'],
-              resources: [`arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}`, `arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}/*`]
+              resources: [
+                `arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}`,
+                `arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}/*`,
+              ],
             }),
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
-              actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
-              resources: [`arn:${cdk.Stack.of(this).partition}:secretsmanager:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:secret:TAK-${envConfig.stackName}-*`]
+              actions: [
+                'secretsmanager:GetSecretValue',
+                'secretsmanager:DescribeSecret',
+              ],
+              resources: [
+                `arn:${cdk.Stack.of(this).partition}:secretsmanager:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:secret:TAK-${envConfig.stackName}-*`,
+              ],
             }),
             new iam.PolicyStatement({
               effect: iam.Effect.ALLOW,
               actions: [
                 'elasticfilesystem:ClientMount',
                 'elasticfilesystem:ClientWrite',
-                'elasticfilesystem:DescribeMountTargets'
+                'elasticfilesystem:DescribeMountTargets',
               ],
-              resources: ['*']
-            })
-          ]
-        })
+              resources: ['*'],
+            }),
+          ],
+        }),
       },
       managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaBasicExecutionRole'),
-        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole')
-      ]
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          'service-role/AWSLambdaBasicExecutionRole',
+        ),
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          'service-role/AWSLambdaVPCAccessExecutionRole',
+        ),
+      ],
     });
 
-    // Grant KMS permissions for S3, Secrets Manager, and EFS encryption
     kmsKey.grantDecrypt(tilesLambdaRole);
-    
-    // Create PMTiles Lambda
-    const tilesTag = cloudtakImageTag ? `pmtiles-${cloudtakImageTag.replace('cloudtak-', '')}` : 'pmtiles-latest';
-    const baseHostname = serviceUrl.replace('https://', '').replace('http://', '');
+
+    const tilesTag = cloudtakImageTag
+      ? `pmtiles-${cloudtakImageTag.replace('cloudtak-', '')}`
+      : 'pmtiles-latest';
+
+    const baseHostname = serviceUrl
+      .replace('https://', '')
+      .replace('http://', '');
     const tilesHostname = `tiles.${baseHostname}`;
-    
+
+    // PMTiles Lambda function
     this.tilesLambda = new lambda.Function(this, 'PMTilesLambda', {
       functionName: `TAK-${envConfig.stackName}-CloudTAK-pmtiles`,
       runtime: lambda.Runtime.FROM_IMAGE,
-      code: tilesImageAsset 
+      code: tilesImageAsset
         ? lambda.Code.fromEcrImage(tilesImageAsset.repository, {
-            tagOrDigest: tilesImageAsset.assetHash
+            tagOrDigest: tilesImageAsset.assetHash,
           })
         : lambda.Code.fromEcrImage(ecrRepository, {
-            tagOrDigest: tilesTag
+            tagOrDigest: tilesTag,
           }),
       handler: lambda.Handler.FROM_IMAGE,
       role: tilesLambdaRole,
@@ -99,148 +138,122 @@ export class LambdaFunctions extends Construct {
       timeout: cdk.Duration.seconds(60),
       description: 'Return Mapbox Vector Tiles from a PMTiles Store',
       environment: {
-        'StackName': cdk.Stack.of(this).stackName,
-        'ASSET_BUCKET': assetBucketName,
-        'PMTILES_URL': `https://${tilesHostname}`,
-        'APIROOT': `https://${tilesHostname}`,  // Legacy value for PMTILES_URL
-        'SigningSecret': `{{resolve:secretsmanager:${signingSecret.secretName}:SecretString::AWSCURRENT}}`
+        StackName: cdk.Stack.of(this).stackName,
+        ASSET_BUCKET: assetBucketName,
+        PMTILES_URL: `https://${tilesHostname}`,
+        APIROOT: `https://${tilesHostname}`,
+        // API_URL required by PMTiles Lambda since CloudTAK v13
+        API_URL: `https://${baseHostname}`,
+        SigningSecret: `{{resolve:secretsmanager:${signingSecret.secretName}:SecretString::AWSCURRENT}}`,
       },
       environmentEncryption: kmsKey,
       vpc,
       vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
       securityGroups: [lambdaSecurityGroup],
-      filesystem: lambda.FileSystem.fromEfsAccessPoint(efsAccessPoint, '/mnt/efs')
+      filesystem: lambda.FileSystem.fromEfsAccessPoint(
+        efsAccessPoint,
+        '/mnt/efs',
+      ),
     });
-    
-    // Note: No need to grant read access when using CloudFormation dynamic references
-    
-    // Create API Gateway for PMTiles
-    // Force REGIONAL endpoint to use local certificate (EDGE requires us-east-1 certificate)
-    const endpointType = apigateway.EndpointType.REGIONAL;
-    
-    this.tilesApi = new apigateway.RestApi(this, 'PMTilesAPI', {
-      restApiName: `TAK-${envConfig.stackName}-CloudTAK-pmtiles`,
-      description: 'PMTiles API Gateway',
-      endpointConfiguration: {
-        types: [endpointType]
-      },
-      binaryMediaTypes: ['application/vnd.mapbox-vector-tile', 'application/x-protobuf'],
+
+    // -------------------------------------------------------------------------
+    // API Gateway v2 (HTTP API) — replaces the former v1 REST API
+    // -------------------------------------------------------------------------
+
+    this.tilesApi = new apigwv2.CfnApi(this, 'PMTilesAPI', {
+      name: `TAK-${envConfig.stackName}-CloudTAK-pmtiles`,
+      protocolType: 'HTTP',
       disableExecuteApiEndpoint: true,
-      deploy: false,  // Disable default deployment to prevent prod stage
-      // No default CORS - will add explicit OPTIONS method like CloudFormation
-      cloudWatchRole: true,
-      cloudWatchRoleRemovalPolicy: cdk.RemovalPolicy.DESTROY,
-      policy: new iam.PolicyDocument({
-        statements: [
-          new iam.PolicyStatement({
-            effect: iam.Effect.ALLOW,
-            principals: [new iam.AnyPrincipal()],
-            actions: ['execute-api:Invoke'],
-            resources: ['*']
-          })
-        ]
-      })
+      description: 'PMTiles HTTP API (v2)',
+      corsConfiguration: {
+        allowHeaders: [
+          'Content-Type',
+          'X-Amz-Date',
+          'Authorization',
+          'X-Api-Key',
+          'X-Amz-Security-Token',
+          'X-Amz-User-Agent',
+        ],
+        allowMethods: ['GET', 'POST', 'OPTIONS'],
+        allowOrigins: ['*'],
+      },
     });
-    
-    // Enable IPv6 support via CloudFormation property
-    const cfnApi = this.tilesApi.node.defaultChild as apigateway.CfnRestApi;
-    cfnApi.addPropertyOverride('EndpointConfiguration.IpAddressType', 'dualstack');
-    
-    // Create API Gateway execution role (like CloudFormation)
-    const apiGatewayRole = new iam.Role(this, 'PMTilesApiGatewayRole', {
-      assumedBy: new iam.ServicePrincipal('apigateway.amazonaws.com'),
-      inlinePolicies: {
-        'lambda-invoke': new iam.PolicyDocument({
-          statements: [
-            new iam.PolicyStatement({
-              effect: iam.Effect.ALLOW,
-              actions: ['lambda:InvokeFunction'],
-              resources: [this.tilesLambda.functionArn]
-            })
-          ]
-        })
-      }
+
+    // Resource-based permission — API Gateway v2 uses this instead of an
+    // execution role (PMTilesApiGatewayRole is no longer needed)
+    this.tilesLambda.addPermission('PMTilesAPIPermission', {
+      principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
+      sourceArn: `arn:${cdk.Stack.of(this).partition}:execute-api:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:${this.tilesApi.ref}/*/*`,
     });
-    
-    // Add proxy resource for all paths
-    const proxyResource = this.tilesApi.root.addResource('{proxy+}');
-    proxyResource.addMethod('GET', new apigateway.LambdaIntegration(this.tilesLambda, {
-      proxy: true,
-      credentialsRole: apiGatewayRole
-    }));
-    
-    // Add explicit OPTIONS method like CloudFormation
-    proxyResource.addMethod('OPTIONS', new apigateway.MockIntegration({
-      integrationResponses: [{
-        statusCode: '204',
-        responseParameters: {
-          'method.response.header.Access-Control-Allow-Headers': "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'",
-          'method.response.header.Access-Control-Allow-Origin': "'*'",
-          'method.response.header.Access-Control-Allow-Methods': "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'"
-        }
-      }],
-      requestTemplates: {
-        'application/json': '{ "statusCode": 200 }'
-      }
-    }), {
-      methodResponses: [{
-        statusCode: '204',
-        responseParameters: {
-          'method.response.header.Access-Control-Allow-Headers': true,
-          'method.response.header.Access-Control-Allow-Origin': true,
-          'method.response.header.Access-Control-Allow-Methods': true
-        }
-      }]
+
+    // Lambda integration (payload format v1.0 for binary tile compatibility)
+    const integration = new apigwv2.CfnIntegration(
+      this,
+      'PMTilesIntegration',
+      {
+        apiId: this.tilesApi.ref,
+        integrationType: 'AWS_PROXY',
+        integrationUri: this.tilesLambda.functionArn,
+        payloadFormatVersion: '1.0',
+      },
+    );
+
+    new apigwv2.CfnRoute(this, 'PMTilesRouteGet', {
+      apiId: this.tilesApi.ref,
+      routeKey: 'GET /{proxy+}',
+      target: `integrations/${integration.ref}`,
     });
-    
-    // No Lambda permissions needed - using API Gateway execution role
-    
-    // Create custom domain and base path mapping (matches CloudFormation approach)
-    const domainName = new apigateway.DomainName(this, 'PMTilesDomain', {
+
+    new apigwv2.CfnRoute(this, 'PMTilesRoutePost', {
+      apiId: this.tilesApi.ref,
+      routeKey: 'POST /{proxy+}',
+      target: `integrations/${integration.ref}`,
+    });
+
+    // $default stage with auto-deploy (no explicit Deployment resource needed)
+    const stage = new apigwv2.CfnStage(this, 'PMTilesStage', {
+      apiId: this.tilesApi.ref,
+      stageName: '$default',
+      autoDeploy: true,
+    });
+
+    // Custom domain mapped to the API
+    const pmtilesDomain = new apigwv2.CfnDomainName(this, 'PMTilesDomain', {
       domainName: tilesHostname,
-      certificate: certificate,
-      endpointType: endpointType,
-      securityPolicy: apigateway.SecurityPolicy.TLS_1_2
+      domainNameConfigurations: [
+        {
+          certificateArn: certificate.certificateArn,
+          endpointType: 'REGIONAL',
+        },
+      ],
     });
-    
-    // Create deployment and stage like CloudFormation
-    const deployment = new apigateway.Deployment(this, 'PMTilesDeployment', {
-      api: this.tilesApi,
-      description: envConfig.stackName
+
+    new apigwv2.CfnApiMapping(this, 'PMTilesApiMapping', {
+      apiId: this.tilesApi.ref,
+      domainName: pmtilesDomain.ref,
+      stage: stage.ref,
     });
-    
-    deployment.node.addDependency(proxyResource);
-    
-    const stage = new apigateway.Stage(this, 'PMTilesStage', {
-      deployment: deployment,
-      stageName: 'tiles'
+
+    // Route53 — alias to the v2 regional domain name
+    const aliasTarget = route53.RecordTarget.fromAlias({
+      bind: () => ({
+        dnsName: pmtilesDomain.attrRegionalDomainName,
+        hostedZoneId: pmtilesDomain.attrRegionalHostedZoneId,
+      }),
     });
-    
-    // Create base path mapping to tiles stage
-    new apigateway.BasePathMapping(this, 'PMTilesBasePathMapping', {
-      domainName: domainName,
-      restApi: this.tilesApi,
-      stage: stage
-    });
-    
-    // Create Route53 records for tiles subdomain (using custom domain)
+
     new route53.ARecord(this, 'PMTilesDNS', {
       zone: hostedZone,
       recordName: `tiles.${envConfig.cloudtak.hostname}`,
-      target: route53.RecordTarget.fromAlias(
-        new route53targets.ApiGatewayDomain(domainName)
-      ),
-      comment: `${cdk.Stack.of(this).stackName} PMTiles API DNS Entry`
+      target: aliasTarget,
+      comment: `${cdk.Stack.of(this).stackName} PMTiles API DNS Entry`,
     });
-    
-    // Add IPv6 support with AAAA record
+
     new route53.AaaaRecord(this, 'PMTilesDNSIPv6', {
       zone: hostedZone,
       recordName: `tiles.${envConfig.cloudtak.hostname}`,
-      target: route53.RecordTarget.fromAlias(
-        new route53targets.ApiGatewayDomain(domainName)
-      ),
-      comment: `${cdk.Stack.of(this).stackName} PMTiles API IPv6 DNS Entry`
+      target: aliasTarget,
+      comment: `${cdk.Stack.of(this).stackName} PMTiles API IPv6 DNS Entry`,
     });
   }
 }

--- a/cdk/lib/constructs/pmtiles-efs.ts
+++ b/cdk/lib/constructs/pmtiles-efs.ts
@@ -115,7 +115,7 @@ export class PMTilesEfs extends Construct {
     // Create cleanup Lambda
     this.cleanupLambda = new lambda.Function(this, 'CleanupLambda', {
       functionName: `TAK-${envConfig.stackName}-CloudTAK-efs-cleanup`,
-      runtime: lambda.Runtime.NODEJS_20_X,
+      runtime: lambda.Runtime.NODEJS_24_X,
       handler: 'index.handler',
       code: lambda.Code.fromInline(`
 import fs from 'fs';

--- a/cdk/lib/constructs/retention-service.ts
+++ b/cdk/lib/constructs/retention-service.ts
@@ -1,0 +1,198 @@
+/**
+ * Retention Service construct
+ *
+ * Scheduled ECS Fargate task that runs daily to clean up expired data via the
+ * CloudTAK retention API. Corresponds to cloudformation/lib/retention.js.
+ *
+ * Resources created:
+ *   - CloudWatch log group
+ *   - IAM task role  (s3:DeleteObject + Secrets Manager read)
+ *   - IAM execution role
+ *   - Fargate task definition  (256 CPU / 512 MB)
+ *   - Security group           (no ingress)
+ *   - EventBridge rule         (rate 1 day)
+ */
+
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as ecrAssets from 'aws-cdk-lib/aws-ecr-assets';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import { ContextEnvironmentConfig } from '../stack-config';
+
+export interface RetentionServiceProps {
+  envConfig: ContextEnvironmentConfig;
+  vpc: ec2.IVpc;
+  ecsCluster: ecs.ICluster;
+  ecrRepository: ecr.IRepository;
+  retentionImageAsset?: ecrAssets.DockerImageAsset;
+  assetBucketName: string;
+  serviceUrl: string;
+  connectionStringSecret: secretsmanager.ISecret;
+  kmsKey: kms.IKey;
+}
+
+export class RetentionService extends Construct {
+  constructor(scope: Construct, id: string, props: RetentionServiceProps) {
+    super(scope, id);
+
+    const {
+      envConfig,
+      vpc,
+      ecsCluster,
+      ecrRepository,
+      retentionImageAsset,
+      assetBucketName,
+      serviceUrl,
+      connectionStringSecret,
+      kmsKey,
+    } = props;
+
+    // CloudWatch log group
+    const logGroup = new logs.LogGroup(this, 'RetentionLogs', {
+      logGroupName: `TAK-${envConfig.stackName}-CloudTAK-retention`,
+      retention: logs.RetentionDays.ONE_WEEK,
+      removalPolicy: envConfig.general.removalPolicy === 'DESTROY'
+        ? cdk.RemovalPolicy.DESTROY
+        : cdk.RemovalPolicy.RETAIN,
+    });
+
+    // Task role — S3 delete + Secrets Manager read
+    const taskRole = new iam.Role(this, 'RetentionTaskRole', {
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+      inlinePolicies: {
+        'retention-policy': new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ['s3:DeleteObject'],
+              resources: [
+                `arn:${cdk.Stack.of(this).partition}:s3:::${assetBucketName}/*`,
+              ],
+            }),
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: [
+                'secretsmanager:Describe*',
+                'secretsmanager:Get*',
+                'secretsmanager:List*',
+              ],
+              resources: [
+                `arn:${cdk.Stack.of(this).partition}:secretsmanager:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:secret:TAK-${envConfig.stackName}-*`,
+              ],
+            }),
+            new iam.PolicyStatement({
+              effect: iam.Effect.ALLOW,
+              actions: ['kms:Decrypt', 'kms:GenerateDataKey'],
+              resources: [kmsKey.keyArn],
+            }),
+          ],
+        }),
+      },
+    });
+
+    // Execution role
+    const executionRole = new iam.Role(this, 'RetentionExecutionRole', {
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          'service-role/AmazonECSTaskExecutionRolePolicy',
+        ),
+      ],
+    });
+
+    connectionStringSecret.grantRead(executionRole);
+
+    // Task definition — 256 CPU / 512 MB (upstream fixed values)
+    const taskDefinition = new ecs.FargateTaskDefinition(
+      this,
+      'RetentionTaskDefinition',
+      {
+        family: `TAK-${envConfig.stackName}-CloudTAK-retention`,
+        cpu: 256,
+        memoryLimitMiB: 512,
+        taskRole,
+        executionRole,
+      },
+    );
+
+    // Resolve container image
+    let containerImage: ecs.ContainerImage;
+    const usePreBuiltImages =
+      cdk.Stack.of(this).node.tryGetContext('usePreBuiltImages') ?? false;
+    const cloudtakImageTag = cdk.Stack.of(this).node.tryGetContext(
+      'cloudtakImageTag',
+    );
+
+    if (usePreBuiltImages && cloudtakImageTag) {
+      const retentionTag = `retention-${cloudtakImageTag.replace('cloudtak-', '')}`;
+      const imageUri = `${cdk.Stack.of(this).account}.dkr.ecr.${cdk.Stack.of(this).region}.amazonaws.com/${cdk.Token.asString(ecrRepository.repositoryName)}:${retentionTag}`;
+      containerImage = ecs.ContainerImage.fromRegistry(imageUri);
+    } else if (retentionImageAsset) {
+      containerImage = ecs.ContainerImage.fromDockerImageAsset(
+        retentionImageAsset,
+      );
+    } else {
+      throw new Error(
+        'Either retentionImageAsset must be provided or usePreBuiltImages must be true with cloudtakImageTag',
+      );
+    }
+
+    taskDefinition.addContainer('retention', {
+      image: containerImage,
+      command: ['npm', 'run', 'run-once'],
+      environment: {
+        AWS_REGION: cdk.Stack.of(this).region,
+        StackName: `TAK-${envConfig.stackName}-CloudTAK`,
+        ASSET_BUCKET: assetBucketName,
+        API_URL: serviceUrl.startsWith('http')
+          ? serviceUrl
+          : `https://${serviceUrl}`,
+      },
+      secrets: {
+        POSTGRES: ecs.Secret.fromSecretsManager(connectionStringSecret),
+      },
+      logging: ecs.LogDrivers.awsLogs({
+        logGroup,
+        streamPrefix: `TAK-${envConfig.stackName}-CloudTAK`,
+      }),
+    });
+
+    // Security group — no ingress, full outbound for API calls
+    const securityGroup = new ec2.SecurityGroup(
+      this,
+      'RetentionSecurityGroup',
+      {
+        vpc,
+        description: 'Security group for CloudTAK retention task (no ingress)',
+        allowAllOutbound: true,
+      },
+    );
+
+    // EventBridge rule — run once per day
+    const schedule = new events.Rule(this, 'RetentionSchedule', {
+      description: 'Schedule for CloudTAK retention runs',
+      schedule: events.Schedule.rate(cdk.Duration.days(1)),
+      enabled: true,
+    });
+
+    schedule.addTarget(
+      new targets.EcsTask({
+        cluster: ecsCluster,
+        taskDefinition,
+        launchType: ecs.LaunchType.FARGATE,
+        platformVersion: ecs.FargatePlatformVersion.LATEST,
+        securityGroups: [securityGroup],
+        subnetSelection: { subnetType: ec2.SubnetType.PUBLIC },
+        assignPublicIp: true,
+      }),
+    );
+  }
+}

--- a/cdk/lib/constructs/security-groups.ts
+++ b/cdk/lib/constructs/security-groups.ts
@@ -55,6 +55,11 @@ export class SecurityGroups extends Construct {
     });
 
     this.database.addIngressRule(this.ecs, ec2.Port.tcp(5432), 'ECS to Database');
+    this.database.addIngressRule(
+      ec2.Peer.ipv6(vpcCidrIpv6),
+      ec2.Port.tcp(5432),
+      'Allow Internal IPv6 network access',
+    );
 
     // ALB outbound - only health checks to ECS
     this.alb.addEgressRule(this.ecs, ec2.Port.tcp(5000), 'Health checks to ECS');

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@tak-nz/cloudtak-cdk",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-cdk/cloud-assembly-schema": "^53.28.0",
-        "aws-cdk-lib": "2.257.0",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "aws-cdk-lib": "2.260.0",
         "axios": "^1.12.0",
-        "constructs": "^10.0.0",
+        "constructs": "^10.5.0",
         "form-data": "^4.0.4",
         "source-map-support": "^0.5.21"
       },
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "22.7.9",
-        "aws-cdk": "2.1128.1",
+        "aws-cdk": "2.1129.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.273",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -41,9 +41,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.28.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
-      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
+      "version": "54.8.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.8.0.tgz",
+      "integrity": "sha512-f891G+Uv4x0/PWTYkA7psEoxHj4//uXEYklB853uFZVHq2zwoH5Eko+uL07wUXZsUiXpZZl8c72KJVnEidR+zg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -51,7 +51,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -66,7 +66,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.0",
+      "version": "7.8.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1265,9 +1265,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1128.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1128.1.tgz",
-      "integrity": "sha512-y9OHn5/BOcIiq409vPvpypMIr7/8M1ScFe8IkFMSCN1/GI/5c73fQ4pfzNq+VDkj86T5zxs7BQ1qU2lQQytdXA==",
+      "version": "2.1129.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1129.0.tgz",
+      "integrity": "sha512-M0EWbjeKW+baUsirjtKuWh7w/9dPxF8taEi2hqo9ecCjGeQxV1dzyosJf+caR3Jh7dFyyT3J8zEtRb/cU971Rw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1278,9 +1278,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.257.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
-      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
+      "version": "2.260.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.260.0.tgz",
+      "integrity": "sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -1297,19 +1297,19 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.4",
-        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "table": "^6.9.0",
         "yaml": "1.10.3"
       },
@@ -1321,7 +1321,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.4",
+      "version": "2.2.5",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1332,11 +1332,37 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.8.0",
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.8.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.8.0.tgz",
+      "integrity": "sha512-f891G+Uv4x0/PWTYkA7psEoxHj4//uXEYklB853uFZVHq2zwoH5Eko+uL07wUXZsUiXpZZl8c72KJVnEidR+zg==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.4",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1346,31 +1372,13 @@
         "node": ">=10"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.28.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
-      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1423,7 +1431,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1483,7 +1491,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1522,7 +1530,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1595,7 +1603,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -4175,7 +4183,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -4183,6 +4183,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -29,17 +29,17 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
-    "aws-cdk": "2.1128.1",
+    "aws-cdk": "2.1129.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.6.3"
   },
   "dependencies": {
-    "@aws-cdk/cloud-assembly-schema": "^53.28.0",
-    "aws-cdk-lib": "2.257.0",
+    "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+    "aws-cdk-lib": "2.260.0",
     "axios": "^1.12.0",
-    "constructs": "^10.0.0",
+    "constructs": "^10.5.0",
     "form-data": "^4.0.4",
     "source-map-support": "^0.5.21"
   }

--- a/cdk/test/unit/constructs/cloudtak-api.test.ts
+++ b/cdk/test/unit/constructs/cloudtak-api.test.ts
@@ -27,6 +27,7 @@ describe('CloudTakApi Construct', () => {
     const signingSecret = secretsmanager.Secret.fromSecretCompleteArn(stack, 'SigningSecret', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret-AbCdEf');
     const adminSecret = secretsmanager.Secret.fromSecretCompleteArn(stack, 'AdminSecret', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:admin-secret-AbCdEf');
     const dbSecret = secretsmanager.Secret.fromSecretCompleteArn(stack, 'DatabaseSecret', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:db-secret-AbCdEf');
+    const geofenceSecret = secretsmanager.Secret.fromSecretCompleteArn(stack, 'GeofenceSecret', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:geofence-secret-AbCdEf');
 
     const etlEcrRepository = CDKTestHelper.createMockEcrRepository(stack, 'EtlEcrRepository');
 
@@ -44,6 +45,7 @@ describe('CloudTakApi Construct', () => {
       serviceUrl: 'https://test.example.com',
       signingSecret,
       adminPasswordSecret: adminSecret,
+      geofenceSecret,
       databaseHostname: 'db.example.com',
       databaseSecret: dbSecret,
       connectionStringSecret: dbSecret
@@ -78,6 +80,7 @@ describe('CloudTakApi Construct', () => {
     const signingSecret2 = secretsmanager.Secret.fromSecretCompleteArn(stack, 'SigningSecret2', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret2-AbCdEf');
     const adminSecret2 = secretsmanager.Secret.fromSecretCompleteArn(stack, 'AdminSecret2', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:admin-secret2-AbCdEf');
     const dbSecret2 = secretsmanager.Secret.fromSecretCompleteArn(stack, 'DatabaseSecret2', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:db-secret2-AbCdEf');
+    const geofenceSecret2 = secretsmanager.Secret.fromSecretCompleteArn(stack, 'GeofenceSecret2', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:geofence-secret2-AbCdEf');
 
     const etlEcrRepository2 = CDKTestHelper.createMockEcrRepository(stack, 'EtlEcrRepository2');
 
@@ -95,6 +98,7 @@ describe('CloudTakApi Construct', () => {
       serviceUrl: 'https://test.example.com',
       signingSecret: signingSecret2,
       adminPasswordSecret: adminSecret2,
+      geofenceSecret: geofenceSecret2,
       databaseHostname: 'db.example.com',
       databaseSecret: dbSecret2,
       connectionStringSecret: dbSecret2
@@ -126,6 +130,7 @@ describe('CloudTakApi Construct', () => {
     const signingSecret3 = secretsmanager.Secret.fromSecretCompleteArn(stack, 'SigningSecret3', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret3-AbCdEf');
     const adminSecret3 = secretsmanager.Secret.fromSecretCompleteArn(stack, 'AdminSecret3', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:admin-secret3-AbCdEf');
     const dbSecret3 = secretsmanager.Secret.fromSecretCompleteArn(stack, 'DatabaseSecret3', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:db-secret3-AbCdEf');
+    const geofenceSecret3 = secretsmanager.Secret.fromSecretCompleteArn(stack, 'GeofenceSecret3', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:geofence-secret3-AbCdEf');
 
     const etlEcrRepository3 = CDKTestHelper.createMockEcrRepository(stack, 'EtlEcrRepository3');
 
@@ -143,6 +148,7 @@ describe('CloudTakApi Construct', () => {
       serviceUrl: 'https://test.example.com',
       signingSecret: signingSecret3,
       adminPasswordSecret: adminSecret3,
+      geofenceSecret: geofenceSecret3,
       databaseHostname: 'db.example.com',
       databaseSecret: dbSecret3,
       connectionStringSecret: dbSecret3

--- a/cdk/test/unit/constructs/lambda-functions.test.ts
+++ b/cdk/test/unit/constructs/lambda-functions.test.ts
@@ -106,8 +106,9 @@ describe('LambdaFunctions Construct', () => {
     });
 
     const template = Template.fromStack(stack);
-    template.hasResourceProperties('AWS::ApiGateway::RestApi', {
-      Name: 'TAK-DevTest-CloudTAK-pmtiles'
+    template.hasResourceProperties('AWS::ApiGatewayV2::Api', {
+      Name: 'TAK-DevTest-CloudTAK-pmtiles',
+      ProtocolType: 'HTTP',
     });
   });
 });


### PR DESCRIPTION
ci: auto-detect and run PMTiles API GW v1→v2 migration in demo pipeline Adds two steps to the deploy-and-test job that run only when a v1 API Gateway domain name containing 'tiles' still exists in the account: 1. 'Check PMTiles API GW Migration Needed' — queries aws apigateway and sets needs-migration=true/false as a step output. 2. 'PMTiles Migration Step 1' — runs only when needs-migration=true: - Deletes any orphaned v2 domain (left over from a previous failed attempt) - Deploys with --context skipPmtilesDomain=true so CloudFormation removes the v1 RestApi + DomainName cleanly The normal 'Deploy Demo with Prod Profile' step always runs afterwards and creates the v2 domain when skipPmtilesDomain is absent. Once the migration is complete these two steps become no-ops on every subsequent pipeline run (the v1 domain check returns empty).