### PR TITLE
fix: cert revocation API method and Docker task image build context

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -159,7 +159,7 @@ jobs:
                   --output type=docker \
                   --provenance=false \
                   -t ${{ steps.tags.outputs.ecr-repo-uri }}:$TASK_TAG \
-                  tasks/$task/
+                  .
                 docker push ${{ steps.tags.outputs.ecr-repo-uri }}:$TASK_TAG
               fi
             fi

--- a/api/routes/connection.ts
+++ b/api/routes/connection.ts
@@ -599,7 +599,7 @@ export default async function router(schema: Schema, config: Config) {
                         new URL(String(config.server.api)),
                         new APIAuthCertificate(config.server.auth.cert, config.server.auth.key),
                     );
-                    await takApi.Credentials.revoke(certHash);
+                    await takApi.Certificate.revoke(certHash);
                     console.log(`Revoked TAK certificate for connection ${req.params.connectionid}`);
                 } catch (err) {
                     // Don't block deletion — log and continue


### PR DESCRIPTION
Fixes two build failures introduced by the v13.26.0 upstream sync.

---

**1. `api/routes/connection.ts` — wrong API method for TAK certificate revocation**

The connection-delete handler calls `takApi.Credentials.revoke(certHash)` to revoke a connection's TAK certificate. `Credentials` is the wrong API class — it handles login credentials, not certificate admin. The `revoke()` method lives on `Certificate` (the cert admin API at `/Marti/api/certadmin/cert/`).

This caused a TypeScript compile error:
```
routes/connection.ts(602,46): error TS2339: Property 'revoke' does not exist on type 'CredentialCommands'.
```

Fix: `takApi.Credentials.revoke()` → `takApi.Certificate.revoke()`

---

**2. `.github/workflows/demo-build.yml` — wrong Docker build context for task images**

Task images were being built with `tasks/$task/` as the Docker build context. The upstream v13 Dockerfiles for `events` and `pmtiles` use `COPY` paths relative to the **repo root**:

```dockerfile
COPY tasks/events/ ./
COPY api/derived-types.d.ts $APP_ROOT/api/derived-types.d.ts
```

With `tasks/events/` as the context, Docker cannot resolve either of these paths, causing:
```
ERROR: failed to solve: "/api/derived-types.d.ts": not found
ERROR: failed to solve: "/tasks/events": not found
```

Fix: change the build context from `tasks/$task/` to `.` (repo root) so all COPY paths resolve correctly.