### PR TITLE
fix(ci): use repo root as Docker build context for task images in production-build

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -154,7 +154,7 @@ jobs:
                   --output type=docker \
                   --provenance=false \
                   -t ${{ steps.tags.outputs.ecr-repo-uri }}:$TASK_TAG \
-                  tasks/$task/
+                  .
                 docker push ${{ steps.tags.outputs.ecr-repo-uri }}:$TASK_TAG
               fi
             fi


### PR DESCRIPTION
Applies the same fix as PR #104 (`demo-build.yml`) to `production-build.yml`.

The events, pmtiles and retention Dockerfiles all use `COPY` paths relative to the **repo root** (e.g. `COPY tasks/events/ ./`, `COPY api/derived-types.d.ts ...`). When the Docker build context is scoped to the individual task directory (`tasks/$task/`), these paths cannot be resolved and the build fails silently by exiting the task loop early — meaning any task whose image doesn't already exist in ECR will never be built.

Changed: `tasks/$task/` → `.` (repo root) as the build context, with `-f tasks/$task/Dockerfile` already specifying the correct Dockerfile path.