### PR TITLE
feat(basemap): add LINZ vector basemap hillshade and sprite support

### DIFF
--- a/LINZ_Vector_Map_Styles/LINZ_Topographic_V2_Hillshade.migrated.json
+++ b/LINZ_Vector_Map_Styles/LINZ_Topographic_V2_Hillshade.migrated.json
@@ -1,0 +1,13087 @@
+[
+    {
+        "id": "Background",
+        "type": "background",
+        "paint": {
+            "background-color": "rgba(184, 220, 242, 1)"
+        },
+        "layout": {
+            "visibility": "visible"
+        },
+        "minzoom": 0
+    },
+    {
+        "id": "Landcover-Sand",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(226, 226, 226, 0.75)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "sand"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Rock-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(0, 0, 0, 1)",
+            "line-width": 30,
+            "line-opacity": {
+                "stops": [
+                    [
+                        14,
+                        0.01
+                    ],
+                    [
+                        15,
+                        0.75
+                    ]
+                ]
+            },
+            "line-pattern": "linz-topographic:rock_narrow_poly_thin"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "bare_rock"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Coastline2",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        1,
+                        "rgba(228, 234, 228, 1)"
+                    ],
+                    [
+                        10,
+                        "rgba(232, 232, 232, 1)"
+                    ],
+                    [
+                        20,
+                        "rgba(232, 232, 232, 1)"
+                    ]
+                ]
+            },
+            "fill-antialias": true
+        },
+        "filter": [
+            "all"
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "boundaries"
+    },
+    {
+        "id": "Poi-Mine-Quarry-Poly",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(205, 205, 205, 1)",
+            "fill-opacity": 0.5
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "mine"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "quarry"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Scatteredscrub",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(204, 222, 195, 1)",
+            "fill-antialias": false,
+            "fill-outline-color": "rgba(210, 210, 210, 0.27)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "scrub"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "distribution"
+                ],
+                "scattered"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Scrub",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(199, 228, 183, 1)",
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(255, 255, 255, 0.27)"
+                    ],
+                    [
+                        10,
+                        "rgba(255, 255, 255, 0.20)"
+                    ],
+                    [
+                        19,
+                        "rgba(255, 255, 255, 0.11)"
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "scrub"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "distribution"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Exotic",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(157, 201, 139, 1)"
+                    ],
+                    [
+                        11,
+                        "rgba(194, 222, 171, 1)"
+                    ]
+                ]
+            },
+            "fill-outline-color": "rgba(210, 210, 210, 0.27)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tree"
+                ],
+                "exotic"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "landuse"
+                ],
+                "wood"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Exotic-Random-Dense-Quarter",
+        "type": "fill",
+        "paint": {
+            "fill-opacity": {
+                "stops": [
+                    [
+                        1,
+                        0.2
+                    ],
+                    [
+                        6,
+                        0.3
+                    ],
+                    [
+                        15,
+                        0.35
+                    ],
+                    [
+                        19,
+                        0.4
+                    ]
+                ]
+            },
+            "fill-pattern": "linz-topographic:exotic_con_poly_random_dense_quarter",
+            "fill-antialias": true,
+            "fill-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tree"
+                ],
+                "exotic"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "landuse"
+                ],
+                "wood"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 11,
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Exotic-Random-Dense-Half",
+        "type": "fill",
+        "paint": {
+            "fill-opacity": {
+                "stops": [
+                    [
+                        1,
+                        0.2
+                    ],
+                    [
+                        6,
+                        0.3
+                    ],
+                    [
+                        15,
+                        0.35
+                    ],
+                    [
+                        19,
+                        0.4
+                    ]
+                ]
+            },
+            "fill-pattern": "linz-topographic:exotic_con_poly_random_dense_half",
+            "fill-antialias": true,
+            "fill-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tree"
+                ],
+                "exotic"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "landuse"
+                ],
+                "wood"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 16,
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Exotic-Random-Dense",
+        "type": "fill",
+        "paint": {
+            "fill-opacity": {
+                "stops": [
+                    [
+                        1,
+                        0.1
+                    ],
+                    [
+                        6,
+                        0.15
+                    ],
+                    [
+                        11,
+                        0.25
+                    ],
+                    [
+                        19,
+                        0.4
+                    ]
+                ]
+            },
+            "fill-pattern": "linz-topographic:exotic_con_poly_random_dense",
+            "fill-antialias": true,
+            "fill-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tree"
+                ],
+                "exotic"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "landuse"
+                ],
+                "wood"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 16,
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Native",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(153, 191, 140, 1)"
+                    ],
+                    [
+                        9,
+                        "rgba(150, 185, 136, 1)"
+                    ],
+                    [
+                        11,
+                        "rgba(144, 183, 125, 1)"
+                    ],
+                    [
+                        14,
+                        "rgba(154, 191, 133, 1)"
+                    ]
+                ]
+            },
+            "fill-outline-color": "rgba(210, 210, 210, 0.27)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tree"
+                ],
+                "native"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Ice",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        1,
+                        "rgba(255, 255, 255, 1)"
+                    ],
+                    [
+                        6,
+                        "rgba(140, 195, 229, 0.2)"
+                    ],
+                    [
+                        10,
+                        "rgba(140, 195, 229, 0.2)"
+                    ]
+                ]
+            },
+            "fill-antialias": true,
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        8,
+                        "rgba(255, 255, 255, 0.01)"
+                    ],
+                    [
+                        10,
+                        "rgba(211, 249, 249, 0.5)"
+                    ],
+                    [
+                        11,
+                        "rgba(57, 158, 158, 0.5)"
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "ice"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Orchard-Fill",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(27, 127, 36, 0.1)"
+                    ],
+                    [
+                        10,
+                        "rgba(27, 127, 36, 0.1)"
+                    ]
+                ]
+            },
+            "fill-opacity": {
+                "stops": [
+                    [
+                        6,
+                        1
+                    ],
+                    [
+                        10,
+                        1
+                    ]
+                ]
+            },
+            "fill-antialias": true,
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        8,
+                        "rgba(255, 255, 255, 0)"
+                    ],
+                    [
+                        10,
+                        "rgba(255, 255, 255, 1)"
+                    ]
+                ]
+            },
+            "fill-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "orchard"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Vineyard-Fill",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(27, 127, 36, 0.2)",
+            "fill-antialias": true,
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        8,
+                        "rgba(255, 255, 255, 0)"
+                    ],
+                    [
+                        10,
+                        "rgba(255, 255, 255, 1)"
+                    ]
+                ]
+            },
+            "fill-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "vineyard"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Swamp-Fill",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(205, 232, 230, 1)"
+                    ],
+                    [
+                        14,
+                        "rgba(224, 236, 238, 1)"
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "swamp"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Swamp-sparse",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(156, 156, 156, 1)",
+            "fill-opacity": 0.5,
+            "fill-pattern": "linz-topographic:swamp_poly_sparse",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "swamp"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 16,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Swamp-sparse-half",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(156, 156, 156, 1)",
+            "fill-opacity": 0.5,
+            "fill-pattern": "linz-topographic:swamp_poly_sparse_half",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "swamp"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 16,
+        "minzoom": 11,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Swamp-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(0, 140, 204, 0.1)"
+                    ],
+                    [
+                        11,
+                        "rgba(0, 140, 204, 0.8)"
+                    ]
+                ]
+            },
+            "line-width": 0.5,
+            "line-dasharray": [
+                6,
+                6,
+                4,
+                4
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "swamp"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "land"
+    },
+    {
+        "id": "Contours-Index-Halo",
+        "type": "line",
+        "paint": {
+            "line-blur": 0.3,
+            "line-color": "rgba(0, 0, 0, 0.75)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.9
+                    ],
+                    [
+                        12,
+                        0.9
+                    ],
+                    [
+                        15,
+                        1.2
+                    ]
+                ]
+            },
+            "line-offset": 0.3,
+            "line-opacity": 0.1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "type"
+                ],
+                "index"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Contours-All",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(206, 103, 6, 0.75)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        0.4
+                    ],
+                    [
+                        16,
+                        0.6
+                    ]
+                ]
+            },
+            "line-opacity": {
+                "stops": [
+                    [
+                        13,
+                        0.3
+                    ],
+                    [
+                        14,
+                        1
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "!",
+                [
+                    "has",
+                    "designated"
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "type"
+                ],
+                "index"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "nat_form"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Contours-Designated",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(206, 103, 6, 0.75)",
+            "line-width": 0.4,
+            "line-dasharray": [
+                30,
+                30
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "designated"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 9,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Contours-Index",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(205, 128, 31, 0.5)"
+                    ],
+                    [
+                        15,
+                        "rgba(207, 129, 43, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        12,
+                        0.7
+                    ],
+                    [
+                        15,
+                        1.2
+                    ]
+                ]
+            },
+            "line-opacity": {
+                "stops": [
+                    [
+                        10,
+                        0
+                    ],
+                    [
+                        11,
+                        1
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "type"
+                ],
+                "index"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Contours-Natural",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(206, 103, 6, 0.75)",
+            "line-width": 0.6,
+            "line-dasharray": [
+                30,
+                10,
+                10,
+                10
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "nat_form"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 9,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Contours-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(193, 104, 9, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(243, 243, 242, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "type"
+                ],
+                "index"
+            ],
+            [
+                "has",
+                "designated"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        12
+                    ]
+                ]
+            },
+            "text-field": "{elevation}",
+            "visibility": "visible",
+            "text-padding": 0,
+            "symbol-spacing": {
+                "stops": [
+                    [
+                        10,
+                        150
+                    ],
+                    [
+                        16,
+                        300
+                    ]
+                ]
+            },
+            "symbol-placement": "line",
+            "text-line-height": 1,
+            "text-keep-upright": false,
+            "text-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 20,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Parcels-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        16,
+                        "rgba(220, 220, 220, 1)"
+                    ],
+                    [
+                        24,
+                        "rgba(147, 147, 147, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        16,
+                        0.75
+                    ],
+                    [
+                        24,
+                        1.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "!",
+                [
+                    "==",
+                    [
+                        "get",
+                        "parcel_intent"
+                    ],
+                    "Road"
+                ]
+            ],
+            [
+                "!",
+                [
+                    "==",
+                    [
+                        "get",
+                        "parcel_intent"
+                    ],
+                    "Hydro"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "parcel_boundaries"
+    },
+    {
+        "id": "hillshade",
+        "type": "hillshade",
+        "source": "__terrain__",
+        "layout": {
+            "visibility": "visible"
+        },
+        "paint": {
+            "hillshade-accent-color": ["interpolate", ["linear"], ["zoom"],
+                0, "rgba(100, 100, 100, 0.400)",
+                3, "rgba(100, 100, 100, 0.400)",
+                9, "rgba(100, 100, 100, 0.333)",
+                11, "rgba(100, 100, 100, 0.267)",
+                14, "rgba(100, 100, 100, 0.400)",
+                17, "rgba(100, 100, 100, 0.600)"
+            ],
+            "hillshade-exaggeration": 0.4,
+            "hillshade-highlight-color": ["interpolate", ["linear"], ["zoom"],
+                0, "rgba(225, 229, 224, 0.800)",
+                3, "rgba(225, 229, 224, 0.800)",
+                9, "rgba(225, 229, 224, 0.333)",
+                11, "rgba(225, 229, 224, 0.0667)",
+                14, "rgba(225, 229, 224, 0.0667)",
+                17, "rgba(225, 229, 224, 0.267)"
+            ],
+            "hillshade-illumination-anchor": "map",
+            "hillshade-illumination-direction": 315,
+            "hillshade-shadow-color": ["interpolate", ["linear"], ["zoom"],
+                0, "rgba(12, 12, 12, 1.00)",
+                3, "rgba(12, 12, 12, 0.800)",
+                9, "rgba(12, 12, 12, 0.667)",
+                11, "rgba(12, 12, 12, 0.533)",
+                14, "rgba(12, 12, 12, 0.400)",
+                17, "rgba(12, 12, 12, 0.600)"
+            ]
+        }
+    },
+    {
+        "id": "Aeroway-Aerodrome",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(211, 211, 211, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "aerodrome"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "Aeroway-Runway-Sealed",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(193, 193, 193, 0.5)",
+            "fill-antialias": false
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "runway"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "sealed"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "Aeroway-Runway-Grass-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(125, 125, 125, 1)",
+            "line-dasharray": [
+                5,
+                5
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "runway"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "surface"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "Aeroway-Runway-Sealed-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(125, 125, 125, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        2,
+                        1
+                    ],
+                    [
+                        10,
+                        0.7
+                    ],
+                    [
+                        19,
+                        0.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "runway"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "sealed"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "Water-Polys-Outline",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(184, 220, 242, 1)"
+                    ],
+                    [
+                        13,
+                        "rgba(0, 140, 204, 0.3)"
+                    ],
+                    [
+                        19,
+                        "rgba(0, 140, 204, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        9,
+                        1
+                    ],
+                    [
+                        15,
+                        2.5
+                    ]
+                ]
+            },
+            "line-offset": 0
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lake"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lagoon"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Canal-Poly-Named",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(204, 232, 245, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(184, 220, 242, 1)"
+                    ],
+                    [
+                        13,
+                        "rgba(0, 140, 204, 0.3)"
+                    ],
+                    [
+                        19,
+                        "rgba(0, 140, 204, 1)"
+                    ]
+                ]
+            },
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 9,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Lagoon",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lagoon"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Lake",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lake"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Lake-Named",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lake"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 0,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-River-Poly-Named",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 5,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Canal-Poly",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-River-Poly",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Landcover-Sand-pattern",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(135, 122, 122, 1)",
+            "fill-opacity": 0.8,
+            "fill-pattern": "linz-topographic:sand_land_poly_quarter",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "sand"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 9,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Sand-land-pattern-half",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(135, 122, 122, 1)",
+            "fill-opacity": 0.45,
+            "fill-pattern": "linz-topographic:sand_land_poly_half",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "sand"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Scree-poly-half",
+        "type": "fill",
+        "paint": {
+            "fill-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0
+                    ],
+                    [
+                        14,
+                        0.25
+                    ]
+                ]
+            },
+            "fill-pattern": "linz-topographic:gravel_poly_half",
+            "fill-antialias": true,
+            "fill-translate": [
+                0,
+                0
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "scree"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Scree-poly",
+        "type": "fill",
+        "paint": {
+            "fill-opacity": 0.3,
+            "fill-pattern": "linz-topographic:gravel_poly",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "scree"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Shingle-poly-quarter",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(0,0,0, 0.75)",
+            "fill-opacity": 0.5,
+            "fill-pattern": "linz-topographic:sand_land_poly_quarter",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "shingle"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 9,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Shingle-poly",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(211, 207, 207, 0.75)",
+            "fill-opacity": 0.5,
+            "fill-pattern": "linz-topographic:sand_land_poly_half",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "shingle"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Shingle-pattern-shade",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(216, 213, 213, 0.5)"
+                    ],
+                    [
+                        19,
+                        "rgba(216, 213, 213, 0.75)"
+                    ]
+                ]
+            },
+            "fill-antialias": false
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "shingle"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Moraine-poly-half",
+        "type": "fill",
+        "paint": {
+            "fill-opacity": 0.4,
+            "fill-pattern": "linz-topographic:moraine_poly_half",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "moraine"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 11,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Moraine-poly",
+        "type": "fill",
+        "paint": {
+            "fill-opacity": 0.5,
+            "fill-pattern": "linz-topographic:moraine_poly",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "moraine"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Moraine-Wall-pattern",
+        "type": "fill",
+        "paint": {
+            "fill-opacity": 0.85,
+            "fill-pattern": {
+                "stops": [
+                    [
+                        12,
+                        "moraine_poly_half"
+                    ],
+                    [
+                        15,
+                        "moraine_poly"
+                    ]
+                ]
+            },
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "moraine_wall"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "land"
+    },
+    {
+        "id": "Water-Reef",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(0, 140, 204, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        2,
+                        0.5
+                    ],
+                    [
+                        10,
+                        1
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                12,
+                2
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "reef"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Waterway-Canal-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        11,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.75)"
+                    ],
+                    [
+                        20,
+                        "rgba(0, 140, 204, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        13,
+                        0.75
+                    ],
+                    [
+                        18,
+                        0.5
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Canal-Ln-Named",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        9,
+                        "rgba(125, 198, 215, 0.01)"
+                    ],
+                    [
+                        10,
+                        "rgba(125, 198, 215, 0.75)"
+                    ],
+                    [
+                        11,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        12,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        13,
+                        1
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Drain-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        11,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.75)"
+                    ],
+                    [
+                        20,
+                        "rgba(0, 140, 204, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        13,
+                        0.75
+                    ],
+                    [
+                        18,
+                        0.5
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "drain"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Drain-Ln-Named",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        9,
+                        "rgba(125, 198, 215, 0.01)"
+                    ],
+                    [
+                        10,
+                        "rgba(125, 198, 215, 0.75)"
+                    ],
+                    [
+                        11,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        12,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        13,
+                        1
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "drain"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-River-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.75)"
+                    ],
+                    [
+                        20,
+                        "rgba(0, 140, 204, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        0.5
+                    ],
+                    [
+                        18,
+                        0.75
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-River-Ln-Named",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        9,
+                        "rgba(125, 198, 215, 0.01)"
+                    ],
+                    [
+                        10,
+                        "rgba(76, 147, 226, 0.3)"
+                    ],
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.4)"
+                    ],
+                    [
+                        18,
+                        "rgba(76, 147, 226, 0.7)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        9,
+                        1
+                    ],
+                    [
+                        12,
+                        1.2
+                    ],
+                    [
+                        15,
+                        1.5
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 24,
+        "minzoom": 9,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Water-Dry-Dock-ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(73, 73, 73, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.75
+                    ],
+                    [
+                        14,
+                        1.5
+                    ],
+                    [
+                        18,
+                        2
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "dry_dock"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Water-Shoal-ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(0, 140, 204, 1)",
+            "line-dasharray": [
+                10,
+                4
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "shoal"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Waterway-Waterfall-Poly",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(63, 117, 150, 1)",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "waterfall"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Waterway-Flume",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(73, 71, 71, 1)",
+            "line-width": 0.75
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "flume"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Rapid",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(0, 140, 204, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        10
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                0.15,
+                12
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "stream"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Rapid-Poly",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-pattern": "linz-topographic:moraine_poly_half",
+            "fill-antialias": false
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "stream"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Waterway-Spillway-Edge",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(78, 78, 78, 1)",
+            "line-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "spillway"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Waterfall-Edge",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(0, 140, 204, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        1
+                    ],
+                    [
+                        15,
+                        1.25
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "waterfall"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "feature"
+                ],
+                "edge"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Waterfall-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(0, 140, 204, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        6
+                    ],
+                    [
+                        15,
+                        14
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                0.1,
+                2.5
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "waterfall"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "feature"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Waterfall-Ln-lines",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(0, 140, 204, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "waterfall"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "feature"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-WaterRace",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        13,
+                        "rgba(0, 140, 204, 0.3)"
+                    ],
+                    [
+                        19,
+                        "rgba(0, 140, 204, 1)"
+                    ]
+                ]
+            },
+            "line-width": 0.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "water_race"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Landuse-Cemetery-poly-half",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(187, 179, 159, 0.75)",
+            "fill-opacity": 0.5,
+            "fill-pattern": "linz-topographic:cemetery_poly_half"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "cemetery"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-GravelPit-shade",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(216, 213, 213, 0.75)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "gravel_pit"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "sites"
+    },
+    {
+        "id": "Landuse-GravelPit-poly-quarter",
+        "type": "fill",
+        "paint": {
+            "fill-pattern": "linz-topographic:gravel_poly_quarter"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "gravel_pit"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 11,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Landuse-GravelPit-poly-half",
+        "type": "fill",
+        "paint": {
+            "fill-pattern": "linz-topographic:gravel_poly_half"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "gravel_pit"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 13,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Landuse-GravelPit-poly",
+        "type": "fill",
+        "paint": {
+            "fill-pattern": "linz-topographic:gravel_poly"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "gravel_pit"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Landuse-Landfill",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(247, 165, 66, 0.65)",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "landfill"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Mangrove-poly-sparse",
+        "type": "fill",
+        "paint": {
+            "fill-pattern": "linz-topographic:mangrove_poly_sparse"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "mangrove"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Mangrove-poly-sparse-half",
+        "type": "fill",
+        "paint": {
+            "fill-pattern": "linz-topographic:mangrove_poly_sparse_half"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "mangrove"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Mangrove",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(96, 154, 101, 0.34)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "mangrove"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-MarineFarm-half",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(25, 114, 242, 0.45)",
+            "fill-opacity": 0.5,
+            "fill-pattern": "linz-topographic:marine_farm_poly_half"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "marine_farm"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 12,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Landuse-MarineFarm",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(25, 114, 242, 0.45)",
+            "fill-opacity": 0.5,
+            "fill-pattern": "linz-topographic:marine_farm_poly"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "marine_farm"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Landuse-Pond",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(184, 220, 242, 1)"
+                    ],
+                    [
+                        13,
+                        "rgba(0, 140, 204, 0.3)"
+                    ],
+                    [
+                        19,
+                        "rgba(0, 140, 204, 1)"
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "pond"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-PumicePit",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(185, 172, 172, 1)",
+            "fill-pattern": "linz-topographic:gravel_poly_quarter"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "pumice_pit"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "sites"
+    },
+    {
+        "id": "Landuse-Reservoir-Covered",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(148, 148, 148, 1)",
+            "fill-outline-color": "rgba(18, 18, 18, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "reservoir"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lid_type"
+                ],
+                "covered"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Landuse-Reservoir-Empty",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-outline-color": "rgba(18, 18, 18, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "reservoir"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "lid_type"
+                ],
+                "covered"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Landuse-Residential",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        1,
+                        "rgba(164, 164, 164, 1)"
+                    ],
+                    [
+                        10,
+                        "rgba(164, 164, 164, 0.95)"
+                    ],
+                    [
+                        13,
+                        "rgba(164, 164, 164, 0.75)"
+                    ],
+                    [
+                        15,
+                        "rgba(164, 164, 164, 0.1)"
+                    ],
+                    [
+                        16,
+                        "rgba(164, 164, 164, 0.01)"
+                    ],
+                    [
+                        20,
+                        "rgba(164, 164, 164, 0.01)"
+                    ]
+                ]
+            },
+            "fill-outline-color": "rgba(164, 164, 164, 0.01)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "residential"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 8,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Cliff-Ln",
+        "type": "line",
+        "paint": {
+            "line-width": 20,
+            "line-opacity": 0.7,
+            "line-pattern": "linz-topographic:cliff_edge"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "cliff"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Cutting-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(81, 79, 79, 1)",
+            "line-width": 20,
+            "line-offset": -3,
+            "line-pattern": "linz-topographic:cutting_edge"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "cutting"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Embankment",
+        "type": "line",
+        "paint": {
+            "line-width": 30,
+            "line-opacity": 1,
+            "line-pattern": "linz-topographic:embankment_gap_cl_thick"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "embankment"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "embkmt_use"
+                ],
+                "stopbank"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-GolfCourse",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(121, 195, 128, 0.2)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "golf_course"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Slip-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(81, 79, 79, 1)",
+            "line-width": 15,
+            "line-offset": 0,
+            "line-pattern": "linz-topographic:cliff_edge"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "slip"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Stopbank",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(61, 58, 58, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        14
+                    ],
+                    [
+                        18,
+                        16
+                    ]
+                ]
+            },
+            "line-opacity": 1,
+            "line-dasharray": [
+                0.1,
+                0.5
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "embankment"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "embkmt_use"
+                ],
+                "stopbank"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Fence-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        15,
+                        "rgba(100, 100, 100, 0.4)"
+                    ],
+                    [
+                        19,
+                        "rgba(100, 100, 100, 0.8)"
+                    ]
+                ]
+            },
+            "line-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "fence"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Fence-Posts",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        15,
+                        "rgba(160, 90, 26, 0.4)"
+                    ],
+                    [
+                        19,
+                        "rgba(160, 90, 26, 0.6)"
+                    ]
+                ]
+            },
+            "line-width": 1.5,
+            "line-offset": 1,
+            "line-dasharray": [
+                1,
+                7
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "fence"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 16.5,
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(148, 199, 111, 0.75)",
+            "line-width": 4,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "tree_row"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Coastline-Ln-2",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        1,
+                        "rgba(9, 132, 186, 1)"
+                    ],
+                    [
+                        6,
+                        "rgba(9, 132, 186, 1)"
+                    ],
+                    [
+                        10,
+                        "rgba(27, 152, 193, 1)"
+                    ],
+                    [
+                        16,
+                        "rgba(34, 164, 212, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        6,
+                        0.5
+                    ],
+                    [
+                        10,
+                        0.55
+                    ],
+                    [
+                        15,
+                        1.25
+                    ],
+                    [
+                        20,
+                        3.5
+                    ]
+                ]
+            },
+            "line-translate-anchor": "map"
+        },
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "boundaries"
+    },
+    {
+        "id": "Poi-FishFarm",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgb(112,172,242)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "fish_farm"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-RifleRange-Fill",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(208, 208, 208, 0.85)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rifle_range"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-RifleRange-Outline",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(55, 54, 54, 0.85)",
+            "line-width": 1.5,
+            "line-dasharray": [
+                5,
+                3
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rifle_range"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-Showground",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(121, 195, 128, 0.2)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "showground"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-SportsField",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(121, 195, 128, 0.2)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "sports_field"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-Storage-Tank-Empty",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(240, 240, 240, 0.85)"
+                    ],
+                    [
+                        10,
+                        "rgba(240, 240, 240, 0.85)"
+                    ]
+                ]
+            },
+            "fill-opacity": {
+                "stops": [
+                    [
+                        14,
+                        1
+                    ],
+                    [
+                        20,
+                        0.2
+                    ]
+                ]
+            },
+            "fill-antialias": true,
+            "fill-outline-color": "rgba(67, 67, 67, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "storage_tank"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "store_item"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Poi-Storage-Tank-Fuel",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(67, 67, 67, 1)",
+            "fill-opacity": {
+                "stops": [
+                    [
+                        14,
+                        1
+                    ],
+                    [
+                        20,
+                        0.2
+                    ]
+                ]
+            },
+            "fill-antialias": false,
+            "fill-outline-color": "rgba(67, 67, 67, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "storage_tank"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "store_item"
+                ],
+                "fuel"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Poi-Storage-Tank-Water",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(110, 167, 205, 1)",
+            "fill-opacity": {
+                "stops": [
+                    [
+                        14,
+                        1
+                    ],
+                    [
+                        20,
+                        0.2
+                    ]
+                ]
+            },
+            "fill-antialias": true,
+            "fill-outline-color": "rgba(67, 67, 67, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "storage_tank"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "store_item"
+                ],
+                "water"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Poi-Siphon",
+        "type": "fill",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "siphon"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Tank-Pt-Background",
+        "type": "circle",
+        "paint": {
+            "circle-radius": {
+                "stops": [
+                    [
+                        12,
+                        2
+                    ],
+                    [
+                        15,
+                        5
+                    ]
+                ]
+            },
+            "circle-opacity": {
+                "stops": [
+                    [
+                        14,
+                        1
+                    ],
+                    [
+                        20,
+                        0.2
+                    ]
+                ]
+            },
+            "circle-stroke-color": "rgba(67, 67, 67, 1)",
+            "circle-pitch-alignment": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "storage_tank"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Tank-Pt-Fill-Empty",
+        "type": "circle",
+        "paint": {
+            "circle-color": "rgba(255, 255, 255, 1)",
+            "circle-radius": {
+                "stops": [
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        15,
+                        3.5
+                    ]
+                ]
+            },
+            "circle-opacity": {
+                "stops": [
+                    [
+                        14,
+                        1
+                    ],
+                    [
+                        20,
+                        0.2
+                    ]
+                ]
+            },
+            "circle-pitch-alignment": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "storage_tank"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "store_item"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Tank-Pt-Fill-Fuel",
+        "type": "circle",
+        "paint": {
+            "circle-color": "rgba(67, 67, 67, 1)",
+            "circle-radius": {
+                "stops": [
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        15,
+                        3.5
+                    ]
+                ]
+            },
+            "circle-opacity": {
+                "stops": [
+                    [
+                        14,
+                        1
+                    ],
+                    [
+                        20,
+                        0.2
+                    ]
+                ]
+            },
+            "circle-pitch-alignment": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "storage_tank"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "store_item"
+                ],
+                "fuel"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Tank-Pt-Fill-Water",
+        "type": "circle",
+        "paint": {
+            "circle-color": "rgba(110, 167, 205, 1)",
+            "circle-radius": {
+                "stops": [
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        15,
+                        3.5
+                    ]
+                ]
+            },
+            "circle-opacity": {
+                "stops": [
+                    [
+                        14,
+                        1
+                    ],
+                    [
+                        20,
+                        0.2
+                    ]
+                ]
+            },
+            "circle-pitch-alignment": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "storage_tank"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "store_item"
+                ],
+                "water"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Boatramp-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(78, 78, 78, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        2
+                    ],
+                    [
+                        15,
+                        5
+                    ],
+                    [
+                        19,
+                        8
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "boatramp"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Boatramp-Fill",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 255, 255, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.4
+                    ],
+                    [
+                        15,
+                        2.5
+                    ],
+                    [
+                        19,
+                        6.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "boatramp"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Dredge-Tailing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(55, 55, 55, 1)",
+            "line-width": 10,
+            "line-opacity": 0.9,
+            "line-pattern": "linz-topographic:dredge_tailing_pnt"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "dredge_tailing"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Mine-Quarry-Outline",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(59, 59, 59, 1)",
+            "line-width": 1.5,
+            "line-dasharray": [
+                2,
+                2
+            ]
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "mine"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "quarry"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Pipeline",
+        "type": "line",
+        "paint": {
+            "line-color": "rgb(235,137,133)",
+            "line-width": {
+                "stops": [
+                    [
+                        6,
+                        0.75
+                    ],
+                    [
+                        10,
+                        1
+                    ],
+                    [
+                        19,
+                        1.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "pipeline"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Racetrack",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(84, 84, 84, 1)",
+            "line-width": 0.75
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "raceway"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-Raceway",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(84, 84, 84, 1)",
+            "line-width": 0.75
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "raceway"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Poi-Slipway-Symbol-Dash",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(64, 64, 64, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        16,
+                        4
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "slipway"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Slipway-Symbol-Line",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(64, 64, 64, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        4
+                    ],
+                    [
+                        16,
+                        18
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                0.15,
+                0.4
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "slipway"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Wharf-Edge",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(73, 73, 73, 1)",
+            "line-width": 1.3
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "wharf_edge"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Poi-Wharf-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(73, 73, 73, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.75
+                    ],
+                    [
+                        14,
+                        1.5
+                    ],
+                    [
+                        18,
+                        2
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "wharf"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Buildings-Shadow",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        15,
+                        "rgba(199, 199, 199, 0.75)"
+                    ],
+                    [
+                        19,
+                        "rgba(125, 125, 125, 1)"
+                    ]
+                ]
+            },
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate": {
+                "base": 1,
+                "stops": [
+                    [
+                        17,
+                        [
+                            1,
+                            1
+                        ]
+                    ],
+                    [
+                        19,
+                        [
+                            3,
+                            3
+                        ]
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "building"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 18,
+        "minzoom": 17,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Buildings",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        14,
+                        "rgba(148, 148, 148, 0.1)"
+                    ],
+                    [
+                        15,
+                        "rgba(148, 148, 148, 1)"
+                    ],
+                    [
+                        17,
+                        "rgba(190, 190, 190, 1)"
+                    ],
+                    [
+                        18,
+                        "rgba(190, 190, 190, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(190, 190, 190, 0.7)"
+                    ]
+                ]
+            },
+            "fill-opacity": 1,
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "building"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Buildings-Outline",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(152, 145, 145,0.75)",
+            "line-width": {
+                "stops": [
+                    [
+                        17,
+                        0.5
+                    ],
+                    [
+                        24,
+                        1
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "building"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 18,
+        "minzoom": 17,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Height-Point",
+        "type": "circle",
+        "paint": {
+            "circle-color": "rgba(47, 47, 46, 1)",
+            "circle-radius": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "peak"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 18,
+        "minzoom": 13,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Height-Point-Labels",
+        "type": "symbol",
+        "paint": {
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(243, 243, 242, 0.75)",
+            "text-halo-width": 1,
+            "text-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "peak"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        11
+                    ]
+                ]
+            },
+            "text-field": "{elevation}",
+            "visibility": "visible",
+            "text-anchor": "bottom-left",
+            "text-offset": [
+                0.2,
+                -0.2
+            ],
+            "text-justify": "auto",
+            "text-optional": false,
+            "text-allow-overlap": false,
+            "icon-pitch-alignment": "auto",
+            "text-variable-anchor": [
+                "bottom-left",
+                "bottom-right"
+            ],
+            "text-ignore-placement": false
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 18,
+        "minzoom": 13,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Transport-FerryCrossing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(0, 140, 204, 1)",
+            "line-dasharray": [
+                15,
+                10
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "ferry"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "ferries"
+    },
+    {
+        "id": "Transport-CycleTracks-Shadow",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(231, 231, 231, 0.4)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        1.5
+                    ],
+                    [
+                        15,
+                        2.5
+                    ],
+                    [
+                        19,
+                        5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "cycle only"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-FootTracks-Shadow",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(231, 231, 231, 0.4)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        1.5
+                    ],
+                    [
+                        15,
+                        2.5
+                    ],
+                    [
+                        19,
+                        5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "foot"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-ClosedFootRouteTracks-Shadow",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(205, 53, 53, 0.4)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        1.5
+                    ],
+                    [
+                        15,
+                        2.5
+                    ],
+                    [
+                        19,
+                        5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "subclass"
+                ],
+                "foot_route_closed"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-ClosedFootTracks-Shadow",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(205, 53, 53, 0.4)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        1.5
+                    ],
+                    [
+                        15,
+                        2.5
+                    ],
+                    [
+                        19,
+                        5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "subclass"
+                ],
+                "foot_closed"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-CycleTracks",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(78, 78, 78, 0.8)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        1
+                    ],
+                    [
+                        15,
+                        1.5
+                    ],
+                    [
+                        19,
+                        3
+                    ]
+                ]
+            },
+            "line-dasharray": {
+                "base": 1,
+                "stops": [
+                    [
+                        13,
+                        [
+                            2.5,
+                            4
+                        ]
+                    ],
+                    [
+                        15,
+                        [
+                            2.5,
+                            3
+                        ]
+                    ],
+                    [
+                        16,
+                        [
+                            2.5,
+                            3
+                        ]
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "cycle only"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-FootTracks",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(78, 78, 78, 0.8)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        1
+                    ],
+                    [
+                        15,
+                        1.5
+                    ],
+                    [
+                        19,
+                        3
+                    ]
+                ]
+            },
+            "line-dasharray": {
+                "base": 1,
+                "stops": [
+                    [
+                        13,
+                        [
+                            2.5,
+                            4
+                        ]
+                    ],
+                    [
+                        15,
+                        [
+                            2.5,
+                            3
+                        ]
+                    ],
+                    [
+                        16,
+                        [
+                            2.5,
+                            3
+                        ]
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "foot"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-VehicleTracks-Shadow",
+        "type": "line",
+        "paint": {
+            "line-blur": 0.75,
+            "line-color": "rgba(231, 231, 231, 0.4)",
+            "line-width": {
+                "base": 1,
+                "stops": [
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        19,
+                        5
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                8
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "vehicle"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-VehicleTracks",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(78, 78, 78, 0.8)",
+            "line-width": {
+                "base": 1,
+                "stops": [
+                    [
+                        13,
+                        1.25
+                    ],
+                    [
+                        15,
+                        2
+                    ],
+                    [
+                        19,
+                        4
+                    ]
+                ]
+            },
+            "line-dasharray": {
+                "base": 1,
+                "stops": [
+                    [
+                        14,
+                        [
+                            5,
+                            3
+                        ]
+                    ],
+                    [
+                        15,
+                        [
+                            5,
+                            4
+                        ]
+                    ],
+                    [
+                        16,
+                        [
+                            6,
+                            6
+                        ]
+                    ],
+                    [
+                        17,
+                        [
+                            8,
+                            8
+                        ]
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "vehicle"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1Casing",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(78, 78, 78, 1)"
+                    ],
+                    [
+                        17,
+                        "rgba(78, 78, 78, 1)"
+                    ],
+                    [
+                        18,
+                        "rgba(96, 96, 96, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.5
+                    ],
+                    [
+                        12,
+                        3
+                    ],
+                    [
+                        13,
+                        4.5
+                    ],
+                    [
+                        15,
+                        5.5
+                    ],
+                    [
+                        18,
+                        11
+                    ],
+                    [
+                        19,
+                        40
+                    ],
+                    [
+                        22,
+                        200
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2Casing",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(78, 78, 78, 1)"
+                    ],
+                    [
+                        17,
+                        "rgba(78, 78, 78, 1)"
+                    ],
+                    [
+                        18,
+                        "rgba(96, 96, 96, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        3.25
+                    ],
+                    [
+                        12,
+                        4.5
+                    ],
+                    [
+                        13,
+                        6.5
+                    ],
+                    [
+                        15,
+                        10
+                    ],
+                    [
+                        18,
+                        17
+                    ],
+                    [
+                        19,
+                        60
+                    ],
+                    [
+                        22,
+                        400
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8
+                    ]
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1HWY-Casing-14",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        1.5
+                    ],
+                    [
+                        10,
+                        1.75
+                    ],
+                    [
+                        12,
+                        3.25
+                    ],
+                    [
+                        13,
+                        5
+                    ],
+                    [
+                        15,
+                        7
+                    ],
+                    [
+                        18,
+                        13
+                    ],
+                    [
+                        19,
+                        50
+                    ],
+                    [
+                        22,
+                        220
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        1
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2HWY-Casing-14",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        3.25
+                    ],
+                    [
+                        10,
+                        4.5
+                    ],
+                    [
+                        12,
+                        6.5
+                    ],
+                    [
+                        13,
+                        8.5
+                    ],
+                    [
+                        15,
+                        12
+                    ],
+                    [
+                        18,
+                        19
+                    ],
+                    [
+                        19,
+                        70
+                    ],
+                    [
+                        22,
+                        450
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-HWY-Casing-14",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        3.5
+                    ],
+                    [
+                        10,
+                        5
+                    ],
+                    [
+                        12,
+                        7.5
+                    ],
+                    [
+                        13,
+                        9
+                    ],
+                    [
+                        15,
+                        13
+                    ],
+                    [
+                        18,
+                        21
+                    ],
+                    [
+                        19,
+                        80
+                    ],
+                    [
+                        22,
+                        470
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-UnMetalled",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 254, 252, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        18,
+                        8
+                    ],
+                    [
+                        19,
+                        35
+                    ],
+                    [
+                        22,
+                        180
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "unmetalled"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1Metalled-White",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 254, 252, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        11,
+                        1
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        18,
+                        8
+                    ],
+                    [
+                        19,
+                        35
+                    ],
+                    [
+                        22,
+                        180
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "metalled"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1Metalled-Orange",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(210, 162, 84, 1)"
+                    ],
+                    [
+                        17,
+                        "rgba(210, 162, 84, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(217, 184, 127, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        11,
+                        1
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        18,
+                        8
+                    ],
+                    [
+                        19,
+                        35
+                    ],
+                    [
+                        22,
+                        180
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                8,
+                5
+            ],
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "metalled"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1-UnderCons",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(133, 130, 130, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        11,
+                        1
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        18,
+                        8
+                    ],
+                    [
+                        19,
+                        35
+                    ],
+                    [
+                        22,
+                        180
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                1,
+                5
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "status"
+                ],
+                "under construction"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1Sealed",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(210, 162, 84, 1)"
+                    ],
+                    [
+                        17,
+                        "rgba(210, 162, 84, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(217, 184, 127, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        11,
+                        1
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        18,
+                        8
+                    ],
+                    [
+                        19,
+                        35
+                    ],
+                    [
+                        22,
+                        180
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "sealed"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2UnMetalled",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 255, 255, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.35
+                    ],
+                    [
+                        11,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        16,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "unmetalled"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2Metalled-White",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 255, 255, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.35
+                    ],
+                    [
+                        11,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        15,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "metalled"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2-UnderCons",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(133, 130, 130, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.35
+                    ],
+                    [
+                        11,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        16,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8
+                    ]
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "status"
+                ],
+                "under construction"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2UnderContruction",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 254, 252, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.35
+                    ],
+                    [
+                        11,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        16,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                5,
+                1
+            ],
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "status"
+                ],
+                "under construction"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2Metalled-Orange",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(210, 162, 84, 1)"
+                    ],
+                    [
+                        17,
+                        "rgba(210, 162, 84, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(217, 184, 127, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.35
+                    ],
+                    [
+                        11,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        15,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                8,
+                5
+            ],
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "metalled"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2+Sealed",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(210, 162, 84, 1)"
+                    ],
+                    [
+                        17,
+                        "rgba(210, 162, 84, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(217, 184, 127, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.35
+                    ],
+                    [
+                        11,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        15,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "sealed"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Cable-Car-People",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(24, 23, 23, 0.80)",
+            "line-width": 1.25
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "cable_car"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "feature"
+                ],
+                "people"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "aerialways"
+    },
+    {
+        "id": "Transport-Cable-Car-Industrial",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(24, 23, 23, 0.80)",
+            "line-width": 2.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "cable_car"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "feature"
+                ],
+                "industrial"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "aerialways"
+    },
+    {
+        "id": "Transport-Ski-Tow",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(24, 23, 23, 0.80)",
+            "line-width": 1.25
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "ski_tow"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "aerialways"
+    },
+    {
+        "id": "Transport-Ski-Lift",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(24, 23, 23, 0.80)",
+            "line-width": 2.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "ski_lift"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "aerialways"
+    },
+    {
+        "id": "Transport-Railway-Siding",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(67, 61, 61, 0.95)",
+            "line-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rail"
+            ],
+            [
+                "has",
+                "rway_use"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Railway-Single",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(67, 61, 61, 0.95)",
+            "line-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rail"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_type"
+                ],
+                "single"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "rway_use"
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Railway-Multiple",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(67, 61, 61, 0.95)",
+            "line-width": {
+                "stops": [
+                    [
+                        11,
+                        2.5
+                    ],
+                    [
+                        19,
+                        4
+                    ],
+                    [
+                        20,
+                        4
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rail"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_type"
+                ],
+                "multiple"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Railway-High",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        8,
+                        "rgba(158, 153, 153, 1)"
+                    ],
+                    [
+                        10,
+                        "rgba(96, 90, 90, 0.95)"
+                    ]
+                ]
+            },
+            "line-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rail"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 11,
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1HWY-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        1.5
+                    ],
+                    [
+                        10,
+                        1.75
+                    ],
+                    [
+                        12,
+                        3.25
+                    ],
+                    [
+                        13,
+                        5
+                    ],
+                    [
+                        15,
+                        7
+                    ],
+                    [
+                        18,
+                        13
+                    ],
+                    [
+                        19,
+                        50
+                    ],
+                    [
+                        22,
+                        220
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        1
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2HWY-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        3.25
+                    ],
+                    [
+                        10,
+                        4.5
+                    ],
+                    [
+                        12,
+                        6.5
+                    ],
+                    [
+                        13,
+                        8.5
+                    ],
+                    [
+                        15,
+                        12
+                    ],
+                    [
+                        18,
+                        19
+                    ],
+                    [
+                        19,
+                        70
+                    ],
+                    [
+                        22,
+                        450
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-HWY-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        3.5
+                    ],
+                    [
+                        10,
+                        5
+                    ],
+                    [
+                        12,
+                        7.5
+                    ],
+                    [
+                        13,
+                        9
+                    ],
+                    [
+                        15,
+                        13
+                    ],
+                    [
+                        18,
+                        21
+                    ],
+                    [
+                        19,
+                        80
+                    ],
+                    [
+                        22,
+                        470
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Roads-9-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        1,
+                        0.2
+                    ],
+                    [
+                        6,
+                        0.8
+                    ],
+                    [
+                        7,
+                        2
+                    ],
+                    [
+                        8,
+                        3.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 9,
+        "minzoom": 0,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1HWY",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(240, 164, 82, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        0.75
+                    ],
+                    [
+                        10,
+                        1
+                    ],
+                    [
+                        11,
+                        1.25
+                    ],
+                    [
+                        13,
+                        2.5
+                    ],
+                    [
+                        15,
+                        4
+                    ],
+                    [
+                        18,
+                        9
+                    ],
+                    [
+                        19,
+                        40
+                    ],
+                    [
+                        22,
+                        200
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2HWY",
+        "type": "line",
+        "paint": {
+            "line-blur": 0,
+            "line-color": "rgba(240, 164, 82, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        1.35
+                    ],
+                    [
+                        10,
+                        1.75
+                    ],
+                    [
+                        11,
+                        2.25
+                    ],
+                    [
+                        13,
+                        5.25
+                    ],
+                    [
+                        15,
+                        8.5
+                    ],
+                    [
+                        18,
+                        15
+                    ],
+                    [
+                        19,
+                        60
+                    ],
+                    [
+                        22,
+                        420
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-HWY",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(240, 164, 82, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        1.5
+                    ],
+                    [
+                        10,
+                        2
+                    ],
+                    [
+                        11,
+                        3
+                    ],
+                    [
+                        13,
+                        5.75
+                    ],
+                    [
+                        15,
+                        9
+                    ],
+                    [
+                        18,
+                        16.5
+                    ],
+                    [
+                        19,
+                        70
+                    ],
+                    [
+                        22,
+                        440
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Roads-9",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(210, 162, 84, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        1,
+                        0.1
+                    ],
+                    [
+                        5,
+                        0.4
+                    ],
+                    [
+                        7,
+                        1.4
+                    ],
+                    [
+                        8,
+                        2.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 9,
+        "minzoom": 0,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Bridge-Foot",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(78, 78, 78, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        15,
+                        4
+                    ],
+                    [
+                        19,
+                        6
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "bridge"
+                ],
+                true
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "use_1"
+                ],
+                "foot traffic"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Bridge-VT",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(78, 78, 78, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        8
+                    ],
+                    [
+                        15,
+                        10
+                    ],
+                    [
+                        18,
+                        18
+                    ],
+                    [
+                        19,
+                        75
+                    ],
+                    [
+                        22,
+                        450
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "bridge"
+                ],
+                true
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "use_1"
+                ],
+                [
+                    "literal",
+                    [
+                        "train",
+                        "vehicle"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Fords",
+        "type": "circle",
+        "paint": {
+            "circle-color": "rgba(0, 140, 204, 1)",
+            "circle-radius": {
+                "stops": [
+                    [
+                        12,
+                        3
+                    ],
+                    [
+                        20,
+                        8
+                    ]
+                ]
+            },
+            "circle-pitch-scale": "map",
+            "circle-pitch-alignment": "map",
+            "circle-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "waterway"
+                ],
+                "ford"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "All-ClosedFootRouteTrack-Labels",
+        "type": "symbol",
+        "paint": {
+            "text-opacity": 0.9,
+            "text-halo-color": "rgba(205, 53, 53, 0.4)",
+            "text-halo-width": 2.5
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "name"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "subclass"
+                ],
+                [
+                    "literal",
+                    [
+                        "foot_route_closed"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        11
+                    ],
+                    [
+                        18,
+                        10
+                    ],
+                    [
+                        19,
+                        30
+                    ],
+                    [
+                        22,
+                        140
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:track_walking_pnt_fill",
+            "text-field": "{name} {status}",
+            "visibility": "visible",
+            "icon-anchor": "bottom",
+            "icon-offset": [
+                0,
+                -3
+            ],
+            "text-anchor": "top",
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-spacing": 100,
+            "text-max-width": 4,
+            "text-transform": "none",
+            "symbol-placement": "point",
+            "icon-allow-overlap": false,
+            "text-allow-overlap": true,
+            "icon-pitch-alignment": "auto",
+            "text-pitch-alignment": "viewport",
+            "icon-ignore-placement": false,
+            "text-ignore-placement": false,
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "All-ClosedFootTrack-Labels",
+        "type": "symbol",
+        "paint": {
+            "text-opacity": 0.9,
+            "icon-halo-blur": 0.5,
+            "icon-halo-color": "rgba(205, 53, 53, 0.4)",
+            "icon-halo-width": 10,
+            "text-halo-color": "rgba(205, 53, 53, 0.4)",
+            "text-halo-width": 2.5
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "name"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "subclass"
+                ],
+                [
+                    "literal",
+                    [
+                        "foot_closed"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        11
+                    ],
+                    [
+                        18,
+                        10
+                    ],
+                    [
+                        19,
+                        30
+                    ],
+                    [
+                        22,
+                        140
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:track_walking_pnt_fill",
+            "text-field": "{name} {status}",
+            "visibility": "visible",
+            "icon-anchor": "bottom",
+            "icon-offset": [
+                0,
+                -3
+            ],
+            "text-anchor": "top",
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-spacing": 100,
+            "text-max-width": 4,
+            "text-transform": "none",
+            "symbol-placement": "point",
+            "icon-allow-overlap": false,
+            "text-allow-overlap": true,
+            "icon-pitch-alignment": "auto",
+            "text-pitch-alignment": "viewport",
+            "icon-ignore-placement": false,
+            "text-ignore-placement": false,
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "All-CycleTrack-Labels",
+        "type": "symbol",
+        "paint": {
+            "text-opacity": 0.9,
+            "text-halo-color": "rgba(243, 243, 242, 0.9)",
+            "text-halo-width": 2.5
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "name"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "cycle only"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        10,
+                        1
+                    ],
+                    [
+                        17,
+                        1.3
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        11
+                    ],
+                    [
+                        18,
+                        10
+                    ],
+                    [
+                        19,
+                        30
+                    ],
+                    [
+                        22,
+                        140
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:racetrack_cycle_pnt",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "bottom",
+            "icon-offset": [
+                0,
+                -3
+            ],
+            "text-anchor": "top",
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-spacing": 100,
+            "text-max-width": 4,
+            "text-transform": "none",
+            "symbol-placement": "point",
+            "icon-allow-overlap": false,
+            "text-allow-overlap": true,
+            "icon-pitch-alignment": "auto",
+            "text-pitch-alignment": "viewport",
+            "icon-ignore-placement": false,
+            "text-ignore-placement": false,
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "All-FootTrack-Labels",
+        "type": "symbol",
+        "paint": {
+            "text-opacity": 0.9,
+            "text-halo-color": "rgba(243, 243, 242, 0.9)",
+            "text-halo-width": 2.5
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "name"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "foot"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "subclass"
+                ],
+                "foot_route_closed"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "subclass"
+                ],
+                "foot_closed"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        11
+                    ],
+                    [
+                        18,
+                        10
+                    ],
+                    [
+                        19,
+                        30
+                    ],
+                    [
+                        22,
+                        140
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:track_walking_pnt_fill",
+            "text-field": "{name} {status}",
+            "visibility": "visible",
+            "icon-anchor": "bottom",
+            "icon-offset": [
+                0,
+                -3
+            ],
+            "text-anchor": "top",
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-spacing": 100,
+            "text-max-width": 4,
+            "text-transform": "none",
+            "symbol-placement": "point",
+            "icon-allow-overlap": false,
+            "text-allow-overlap": true,
+            "icon-pitch-alignment": "auto",
+            "text-pitch-alignment": "viewport",
+            "icon-ignore-placement": false,
+            "text-ignore-placement": false,
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Landuse-Boom",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(73, 73, 73, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.5
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        4
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "boom"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Landuse-Breakwater",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(73, 73, 73, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.5
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        4
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "breakwater"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pier_lines"
+    },
+    {
+        "id": "Landuse-Dam",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(78, 78, 78, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        4
+                    ],
+                    [
+                        15,
+                        8.5
+                    ],
+                    [
+                        19,
+                        14.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "dam"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "dam_lines"
+    },
+    {
+        "id": "Landuse-Ladder",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(65, 63, 63, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "ladder"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-MarineFarm-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(25, 114, 242, 0.45)",
+            "line-width": 3
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "marine_farm"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Poi-Beacon",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(224, 168, 33, 1)",
+            "icon-opacity": 0.9,
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "beacon"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "type"
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1.3
+                    ],
+                    [
+                        15,
+                        1.6
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 8,
+            "icon-image": "linz-topographic:beacon_beacon_water_pnt",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "right",
+            "text-anchor": "left",
+            "text-justify": "right"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Beacon-Lighthouse",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(131, 82, 19, 1)",
+            "text-halo-blur": 0.5,
+            "text-translate": [
+                15,
+                0
+            ],
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "beacon"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "type"
+                ],
+                "lighthouse"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1.3,
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "icon-image": "linz-topographic:beacon_lighthouse_land_pnt",
+            "text-field": "{name}",
+            "icon-anchor": "center",
+            "text-anchor": "left",
+            "text-justify": "right",
+            "icon-allow-overlap": true,
+            "text-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Bivouac-Rock",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(73, 68, 68, 1)",
+            "text-opacity": 1,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "amenity"
+                ],
+                "bivouac"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "materials"
+                ],
+                "rock"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1,
+            "text-font": [
+                "Roboto Bold"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:cave_pnt",
+            "text-field": {
+                "stops": [
+                    [
+                        6,
+                        ""
+                    ],
+                    [
+                        12,
+                        "{name}"
+                    ]
+                ]
+            },
+            "text-anchor": "left",
+            "text-offset": [
+                1,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 5,
+            "icon-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Bivouac",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(73, 68, 68, 1)",
+            "text-opacity": 1,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "amenity"
+                ],
+                "bivouac"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "materials"
+                ],
+                "rock"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1,
+            "text-font": [
+                "Roboto Bold"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:building_pnt_hut",
+            "text-field": {
+                "stops": [
+                    [
+                        6,
+                        ""
+                    ],
+                    [
+                        12,
+                        "{name}"
+                    ]
+                ]
+            },
+            "text-anchor": "left",
+            "text-offset": [
+                1,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 5,
+            "icon-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Buoy",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "seamark"
+                ],
+                "buoy"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.7,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 12,
+            "icon-image": "linz-topographic:circle_pnt_line",
+            "text-field": "Buoy",
+            "text-offset": [
+                1.5,
+                -1
+            ]
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Cave-Pt",
+        "type": "symbol",
+        "paint": {
+            "text-halo-blur": 0.5,
+            "text-translate": [
+                15,
+                0
+            ],
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "natural"
+                ],
+                "cave_entrance"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:cave_pnt",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "text-anchor": "left",
+            "text-justify": "left",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Cemetery-Pt",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0.2
+                    ],
+                    [
+                        13,
+                        0.9
+                    ]
+                ]
+            },
+            "text-opacity": {
+                "stops": [
+                    [
+                        13,
+                        0.1
+                    ],
+                    [
+                        14,
+                        1
+                    ]
+                ]
+            },
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "landuse"
+                ],
+                "cemetery"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        0.8
+                    ],
+                    [
+                        18,
+                        1.2
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:grave_pnt",
+            "text-field": {
+                "stops": [
+                    [
+                        12,
+                        ""
+                    ],
+                    [
+                        13,
+                        "{landuse}"
+                    ]
+                ]
+            },
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                0.5
+            ]
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Chimney",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "chimney"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1.5,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "icon-image": "linz-topographic:chimney_pnt",
+            "text-field": "",
+            "text-anchor": "left",
+            "text-offset": [
+                1,
+                0
+            ],
+            "text-justify": "right"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Dredge",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "dredge"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.8,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "icon-image": "linz-topographic:square_pnt_fill",
+            "text-field": "",
+            "text-anchor": "bottom-left",
+            "text-justify": "left"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-FishFarm-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(239, 239, 239, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "fish_farm"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Roboto Bold Italic"
+            ],
+            "text-size": 10,
+            "text-field": "{species}"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 16,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-Flare",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "icon-opacity": 0.9,
+            "text-opacity": {
+                "stops": [
+                    [
+                        14,
+                        0.2
+                    ],
+                    [
+                        15,
+                        1
+                    ]
+                ]
+            },
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "flare"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.8,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 12,
+            "icon-image": "linz-topographic:square_pnt_fill",
+            "text-field": "{man_made}",
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                0.5
+            ]
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Floodgate",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "waterway"
+                ],
+                "sluice_gate"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        15,
+                        1.5
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        12
+                    ],
+                    [
+                        16,
+                        18
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:gate_pnt",
+            "text-field": {
+                "stops": [
+                    [
+                        12,
+                        ""
+                    ],
+                    [
+                        16,
+                        "floodgate"
+                    ]
+                ]
+            },
+            "text-offset": [
+                2.5,
+                -0.8
+            ]
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-GasValve",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "pipeline"
+                ],
+                "valve"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        12,
+                        8
+                    ],
+                    [
+                        14,
+                        10
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:circle_pnt_line",
+            "text-field": "Gas valve",
+            "text-offset": [
+                0,
+                1
+            ]
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Gate",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0.3
+                    ],
+                    [
+                        13,
+                        0.9
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "barrier"
+                ],
+                "gate"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        16,
+                        1.5
+                    ]
+                ]
+            },
+            "text-font": [],
+            "icon-image": "linz-topographic:gate_pnt",
+            "text-field": "",
+            "icon-rotate": 0,
+            "icon-allow-overlap": false,
+            "text-allow-overlap": true,
+            "icon-pitch-alignment": "map"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-GeoBore",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0.25
+                    ],
+                    [
+                        13,
+                        1
+                    ]
+                ]
+            },
+            "text-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "geo_bore"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.85,
+            "text-font": [],
+            "icon-image": "linz-topographic:geobore_pnt_thick",
+            "icon-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-GeoBore-Label",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "geo_bore"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 10,
+            "text-field": "{man_made}",
+            "visibility": "visible",
+            "text-offset": [
+                0,
+                1
+            ],
+            "icon-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 19,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Grave-Pt",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": 0.9
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "amenity"
+                ],
+                "grave_yard"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        0.9
+                    ],
+                    [
+                        18,
+                        1.2
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:grave_pnt",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Historic-Site",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(203, 12, 12, 1)",
+            "icon-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0.1
+                    ],
+                    [
+                        14,
+                        1
+                    ]
+                ]
+            },
+            "text-opacity": {
+                "stops": [
+                    [
+                        16,
+                        0.1
+                    ],
+                    [
+                        17,
+                        1
+                    ]
+                ]
+            },
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "historic"
+                ],
+                "site"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:historic_site_pnt",
+            "text-field": "{ref}",
+            "text-anchor": "left",
+            "text-offset": [
+                1,
+                0
+            ],
+            "text-justify": "left"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Hut-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(73, 68, 68, 1)",
+            "text-opacity": 1,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.2
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "hut"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1,
+            "text-font": [
+                "Roboto Bold"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:building_pnt_hut",
+            "text-field": {
+                "stops": [
+                    [
+                        6,
+                        ""
+                    ],
+                    [
+                        12,
+                        "{name}"
+                    ]
+                ]
+            },
+            "text-anchor": "left",
+            "text-offset": [
+                1,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 5,
+            "icon-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Kiln",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "kiln"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.75,
+            "text-font": [
+                "Roboto Light"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:circle_pnt_line",
+            "text-field": "{man_made}",
+            "text-anchor": "left",
+            "text-offset": [
+                1,
+                0
+            ],
+            "text-justify": "right"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Ladder",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "ladder"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Roboto Light"
+            ],
+            "text-field": "ladder",
+            "text-anchor": "top",
+            "symbol-placement": "line"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Ladder-Pt",
+        "type": "symbol",
+        "paint": {
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "ladder"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.5,
+            "text-font": [
+                "Roboto Light"
+            ],
+            "text-size": 13,
+            "icon-image": "linz-topographic:circle_pnt_fill",
+            "text-field": "ladder",
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                0.5
+            ],
+            "text-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Mast-Label-Triangle",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": 0.85
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "mast"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1.1,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:mast_pnt",
+            "text-field": "",
+            "visibility": "visible",
+            "text-offset": [
+                0,
+                1
+            ],
+            "icon-allow-overlap": true,
+            "text-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Mine-Pt",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": 0.8,
+            "text-opacity": 0.9,
+            "text-halo-blur": 0.75,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 0.75
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "mine"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.7,
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:square_pnt_fill",
+            "text-field": "{name} {substance} {visibility} {status} ",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "left",
+            "text-offset": [
+                1,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Monument",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(98, 53, 0, 1)",
+            "icon-opacity": 0.85,
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "historic"
+                ],
+                "monument"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1.2
+                    ],
+                    [
+                        16,
+                        1.6
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 9,
+            "icon-image": "linz-topographic:monument_pnt",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "left",
+            "text-offset": [
+                1.5,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 5,
+            "icon-allow-overlap": true,
+            "text-allow-overlap": true,
+            "text-radial-offset": 0
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Pa",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": {
+                "stops": [
+                    [
+                        6,
+                        0.6
+                    ],
+                    [
+                        11,
+                        0.7
+                    ],
+                    [
+                        15,
+                        0.8
+                    ],
+                    [
+                        19,
+                        1
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "fortification_type"
+                ],
+                "pa"
+            ]
+        ],
+        "layout": {
+            "icon-image": "linz-topographic:pa_pnt",
+            "text-anchor": "center",
+            "icon-allow-overlap": true,
+            "text-ignore-placement": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Pylon",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": {
+                "stops": [
+                    [
+                        15,
+                        0.01
+                    ],
+                    [
+                        16,
+                        0.6
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "power"
+                ],
+                "pole"
+            ]
+        ],
+        "layout": {
+            "text-font": [],
+            "icon-image": "linz-topographic:square_pnt_line",
+            "icon-pitch-alignment": "map",
+            "text-pitch-alignment": "map",
+            "icon-rotation-alignment": "auto",
+            "text-rotation-alignment": "map"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Quarry-Poly-NoName",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(47, 47, 47, 1)",
+            "icon-opacity": 0.65,
+            "text-halo-blur": 0.75,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "quarry"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "name"
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.6,
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:square_pnt_fill",
+            "text-field": "{kind} {substance} {status}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                0.5
+            ],
+            "text-justify": "center",
+            "text-max-width": 4,
+            "icon-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Quarry-Poly-Name",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(47, 47, 47, 1)",
+            "icon-opacity": 0.65,
+            "text-halo-blur": 0.75,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 0.75,
+            "icon-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "quarry"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.6,
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:square_pnt_fill",
+            "text-field": "{name} {substance} {status}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "icon-offset": [
+                0,
+                0
+            ],
+            "text-anchor": "left",
+            "text-offset": [
+                1,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 4,
+            "icon-allow-overlap": true,
+            "text-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Racetrack-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(129, 123, 123, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1,
+            "icon-translate-anchor": "viewport",
+            "text-translate-anchor": "viewport"
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "raceway"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 10,
+            "text-field": "{name}",
+            "text-pitch-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-Raceway-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(129, 123, 123, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1,
+            "icon-translate-anchor": "viewport",
+            "text-translate-anchor": "viewport"
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "raceway"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 10,
+            "text-field": "{name}",
+            "text-pitch-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Poi-Radar-Dome",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "radar_dome"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.5,
+            "icon-image": "linz-topographic:circle_pnt_fill"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Railway-Symbol",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(94, 94, 94, 1)",
+            "text-halo-blur": 0.5,
+            "text-translate": [
+                0,
+                -15
+            ],
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "station"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        0.4
+                    ],
+                    [
+                        13,
+                        1
+                    ],
+                    [
+                        20,
+                        2
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        10
+                    ],
+                    [
+                        16,
+                        10
+                    ],
+                    [
+                        17,
+                        16
+                    ],
+                    [
+                        18,
+                        19
+                    ]
+                ]
+            },
+            "icon-image": {
+                "stops": [
+                    [
+                        12,
+                        "rail_station_pnt_red"
+                    ],
+                    [
+                        13,
+                        "rail_station_train_diesel_pnt_red"
+                    ]
+                ]
+            },
+            "text-field": {
+                "stops": [
+                    [
+                        12,
+                        "{name}"
+                    ],
+                    [
+                        13,
+                        "{name}"
+                    ]
+                ]
+            },
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "left",
+            "text-offset": [
+                1.25,
+                1.5
+            ],
+            "text-justify": "left",
+            "icon-optional": true,
+            "text-max-width": 5,
+            "icon-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "public_transport"
+    },
+    {
+        "id": "Poi-Redoubt",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "historic"
+                ],
+                "redoubt"
+            ]
+        ],
+        "layout": {
+            "icon-image": "linz-topographic:redoubt_pnt"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-RifleRange-Label",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0.25
+                    ],
+                    [
+                        13,
+                        0.9
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rifle_range"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1.2
+                    ],
+                    [
+                        15,
+                        1.5
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 9,
+            "icon-image": "linz-topographic:rifle_range_pnt",
+            "text-field": ""
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-Satellite-Station-Pt",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "telescope"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1.2
+                    ],
+                    [
+                        15,
+                        1.5
+                    ],
+                    [
+                        17,
+                        1.7
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:satellite_station_pnt",
+            "visibility": "visible",
+            "icon-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Shaft",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": 0.9
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "mineshaft"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.85,
+            "icon-image": "linz-topographic:shaft_pnt"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Sinkhole",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "natural"
+                ],
+                "sinkhole"
+            ]
+        ],
+        "layout": {
+            "icon-image": "linz-topographic:sinkhole_pnt"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Siphon-Pt",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": 0.85
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "waterway"
+                ],
+                "siphon"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.8,
+            "icon-image": "linz-topographic:circle_pnt_fill"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Showground-Symbol",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(121, 195, 128, 0.2)",
+            "text-halo-color": "rgba(255, 255, 255, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "showground"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1.2
+                    ],
+                    [
+                        15,
+                        1.5
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 9,
+            "icon-image": "linz-topographic:showground_pnt",
+            "text-field": ""
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-Soakhole",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": 0.8
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "waterway"
+                ],
+                "soakhole"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        0.25
+                    ],
+                    [
+                        14,
+                        0.5
+                    ],
+                    [
+                        19,
+                        1
+                    ]
+                ]
+            },
+            "text-font": [],
+            "text-size": 10,
+            "icon-image": "linz-topographic:well_pnt_small_fill",
+            "text-field": "",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-SportsField-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(37, 108, 41, 1)",
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "sports_field"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 9,
+            "text-field": "{name}"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-Stockyard",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0.25
+                    ],
+                    [
+                        13,
+                        1
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "farmyard"
+                ],
+                "stockyard"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        0.9
+                    ],
+                    [
+                        14,
+                        1
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:stockyard_pnt"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Trig-Elevation",
+        "type": "symbol",
+        "paint": {
+            "text-halo-blur": 0.75,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 0.75
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "trig_point"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 9,
+            "text-field": "{elevation} m",
+            "visibility": "visible",
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                1.3
+            ],
+            "text-justify": "center"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Trig-Symbol",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(69, 50, 50, 1)",
+            "icon-opacity": 0.6,
+            "text-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0.2
+                    ],
+                    [
+                        13,
+                        1
+                    ]
+                ]
+            },
+            "text-halo-blur": 0.75,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 0.75
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "trig_point"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.75,
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:triangle_pnt_fill",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "text-anchor": "bottom",
+            "text-offset": [
+                0,
+                -0.7
+            ],
+            "text-justify": "left"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Well",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(133, 112, 112, 1)",
+            "text-halo-blur": 0.75,
+            "text-halo-color": "rgba(242, 242, 242, 1)",
+            "text-halo-width": 0.75
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "water_well"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        14,
+                        1.4
+                    ],
+                    [
+                        15,
+                        1
+                    ],
+                    [
+                        17,
+                        1.4
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 10,
+            "icon-image": {
+                "stops": [
+                    [
+                        12,
+                        "well_pnt_small_line"
+                    ],
+                    [
+                        14,
+                        "well_pnt_small_line"
+                    ],
+                    [
+                        15,
+                        "well_pnt_large_line"
+                    ],
+                    [
+                        16,
+                        "well_pnt_large_line"
+                    ]
+                ]
+            },
+            "text-field": "{status}",
+            "icon-anchor": "center",
+            "text-anchor": "left",
+            "text-offset": [
+                0.75,
+                0
+            ],
+            "text-justify": "left"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Windmill",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(63, 44, 44, 1)",
+            "icon-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0.25
+                    ],
+                    [
+                        13,
+                        1
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(252, 249, 249, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "wind_turbine"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        11,
+                        1.2
+                    ],
+                    [
+                        15,
+                        1.5
+                    ],
+                    [
+                        18,
+                        1.8
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 8.5,
+            "icon-image": "linz-topographic:windmill_pnt",
+            "text-field": "",
+            "visibility": "visible",
+            "icon-anchor": "bottom",
+            "icon-offset": [
+                0,
+                0
+            ],
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                0
+            ],
+            "text-justify": "center"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Wreck",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(69, 50, 50, 1)",
+            "text-translate": [
+                10,
+                0
+            ],
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "historic"
+                ],
+                "wreck"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1.3
+                    ],
+                    [
+                        14,
+                        1.5
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 11,
+            "icon-image": "linz-topographic:wreck_ship_pnt",
+            "text-field": "{name}",
+            "icon-anchor": "center",
+            "text-anchor": "left",
+            "text-justify": "left",
+            "text-max-width": 7,
+            "icon-allow-overlap": true,
+            "icon-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Orchard-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(27, 77, 29, 1)",
+            "icon-opacity": 0.9,
+            "text-halo-blur": 0.5,
+            "text-translate": [
+                0,
+                6
+            ],
+            "text-halo-color": "rgba(255, 255, 255, 0.59)",
+            "text-halo-width": 1,
+            "text-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "orchard"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        14,
+                        10
+                    ],
+                    [
+                        20,
+                        16
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:orchard_pnt_dual",
+            "text-field": {
+                "stops": [
+                    [
+                        6,
+                        ""
+                    ],
+                    [
+                        16,
+                        "{kind}"
+                    ]
+                ]
+            },
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "top",
+            "text-justify": "auto",
+            "icon-allow-overlap": true,
+            "icon-pitch-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Vineyard-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(17, 63, 29, 0.85)",
+            "icon-opacity": 0.9,
+            "text-halo-blur": 0.5,
+            "text-translate": [
+                0,
+                6
+            ],
+            "text-halo-color": "rgba(255, 255, 255, 0.59)",
+            "text-halo-width": 1,
+            "text-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "vineyard"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        14,
+                        10
+                    ],
+                    [
+                        20,
+                        16
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:vineyard_pnt_dual",
+            "text-field": {
+                "stops": [
+                    [
+                        6,
+                        ""
+                    ],
+                    [
+                        16,
+                        "{kind}"
+                    ]
+                ]
+            },
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "top",
+            "text-justify": "auto",
+            "icon-pitch-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Building3D",
+        "type": "fill-extrusion",
+        "paint": {
+            "fill-extrusion-color": "rgba(190, 190, 190, 1)",
+            "fill-extrusion-height": {
+                "base": 1,
+                "stops": [
+                    [
+                        10,
+                        1.5
+                    ],
+                    [
+                        14,
+                        2.5
+                    ]
+                ]
+            },
+            "fill-extrusion-opacity": 0.5,
+            "fill-extrusion-translate-anchor": "viewport",
+            "fill-extrusion-vertical-gradient": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "building"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 18,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Transport-Tunnel-VT",
+        "type": "line",
+        "paint": {
+            "line-blur": 0,
+            "line-color": "rgba(98, 88, 13, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        15,
+                        1.5
+                    ],
+                    [
+                        19,
+                        4
+                    ]
+                ]
+            },
+            "line-opacity": 1,
+            "line-dasharray": [
+                4,
+                2.5
+            ],
+            "line-gap-width": 8
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tunnel"
+                ],
+                true
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Landuse-Powerline",
+        "type": "line",
+        "paint": {
+            "line-blur": 0.75,
+            "line-color": "rgba(57, 57, 57, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        9,
+                        0.75
+                    ],
+                    [
+                        12,
+                        1
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "powerline"
+            ],
+            [
+                "has",
+                "support_ty"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "miter",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Powerline-Pylon",
+        "type": "line",
+        "paint": {
+            "line-blur": 0.75,
+            "line-color": "rgba(57, 57, 57, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        9,
+                        0.75
+                    ],
+                    [
+                        12,
+                        1
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "powerline"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "support_ty"
+                ],
+                "pylon"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "miter",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 14,
+        "minzoom": 11,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Telephone",
+        "type": "line",
+        "paint": {
+            "line-blur": 0.75,
+            "line-color": "rgba(57, 57, 57, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        9,
+                        0.75
+                    ],
+                    [
+                        12,
+                        1
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "telephone"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "miter",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Walkwire",
+        "type": "line",
+        "paint": {
+            "line-blur": 0.75,
+            "line-color": "rgba(57, 57, 57, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        9,
+                        0.75
+                    ],
+                    [
+                        12,
+                        3
+                    ],
+                    [
+                        18,
+                        5
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "walkwire"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "miter",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Dam-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(78, 78, 78, 1)",
+            "text-halo-blur": 0.75,
+            "text-halo-color": "rgba(252, 252, 252, 1)",
+            "text-halo-width": 0.75
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "dam"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Roboto Black Italic"
+            ],
+            "text-field": "{name}",
+            "icon-offset": [
+                0,
+                0
+            ],
+            "text-anchor": "bottom",
+            "text-offset": [
+                0,
+                0
+            ],
+            "text-justify": "center",
+            "symbol-placement": "line",
+            "icon-keep-upright": false,
+            "text-pitch-alignment": "viewport",
+            "text-rotation-alignment": "auto"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "dam_lines"
+    },
+    {
+        "id": "Landuse-GravelPit-Label",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "gravel_pit"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.8,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        12,
+                        6
+                    ],
+                    [
+                        15,
+                        10
+                    ]
+                ]
+            },
+            "text-field": ""
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Landuse-Grave-Pt",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "amenity"
+                ],
+                "grave_yard"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "icon-image": "linz-topographic:grave_pnt",
+            "text-field": "",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Landuse-Landfill-Symbol",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(28, 25, 17, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(247, 165, 66, 0.75)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "landfill"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        1.2
+                    ],
+                    [
+                        16,
+                        1.5
+                    ]
+                ]
+            },
+            "text-font": [
+                "Roboto Italic"
+            ],
+            "text-size": 12,
+            "icon-image": "linz-topographic:landfill_pnt",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "right",
+            "text-anchor": "left",
+            "text-offset": [
+                0.5,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Mangrove-Symbol",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": 0.8
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "mangrove"
+            ]
+        ],
+        "layout": {
+            "text-font": [],
+            "icon-image": "linz-topographic:mangrove_pnt"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 14,
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-MarineFarm-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(239, 239, 239, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "marine_farm"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Roboto Bold Italic"
+            ],
+            "text-size": 10,
+            "text-field": "{species}"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Landuse-PumicePit-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(34, 34, 34, 1)",
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "pumice_pit"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        12,
+                        6
+                    ],
+                    [
+                        15,
+                        10
+                    ]
+                ]
+            },
+            "text-field": {
+                "stops": [
+                    [
+                        6,
+                        ""
+                    ],
+                    [
+                        15,
+                        "{kind}"
+                    ]
+                ]
+            }
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Landuse-Tower",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "man_made"
+                ],
+                "tower"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "icon-image": "linz-topographic:tower_pnt",
+            "text-field": ""
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Landcover-Tree-Pt",
+        "type": "circle",
+        "paint": {
+            "circle-color": "rgba(121, 160, 72, 0.4)",
+            "circle-radius": {
+                "stops": [
+                    [
+                        8,
+                        1.5
+                    ],
+                    [
+                        12,
+                        2.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "natural"
+                ],
+                "tree"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Landcover-Fumarole",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(176, 0, 0, 1)",
+            "icon-opacity": {
+                "stops": [
+                    [
+                        12,
+                        0.25
+                    ],
+                    [
+                        13,
+                        1
+                    ]
+                ]
+            },
+            "text-opacity": {
+                "stops": [
+                    [
+                        16,
+                        0.2
+                    ],
+                    [
+                        17,
+                        1
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "natural"
+                ],
+                "fumarole"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        0.4
+                    ],
+                    [
+                        13,
+                        0.65
+                    ],
+                    [
+                        14,
+                        0.7
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 12,
+            "icon-image": "linz-topographic:fumarole_pnt",
+            "text-field": {
+                "stops": [
+                    [
+                        15,
+                        ""
+                    ],
+                    [
+                        16,
+                        "{natural}"
+                    ],
+                    [
+                        17,
+                        "{natural}"
+                    ]
+                ]
+            },
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                0.5
+            ]
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "Landcover-GolfCourse-Symbol",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(27, 77, 29, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "golf_course"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1.2,
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 9,
+            "icon-image": "linz-topographic:golf_course_pnt_dual",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "right",
+            "text-anchor": "left",
+            "text-offset": [
+                0.5,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 6,
+            "icon-pitch-alignment": "viewport",
+            "icon-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Rock-Pt",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "natural"
+                ],
+                "rock"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "geological"
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": 1,
+            "icon-image": "linz-topographic:rock_pnt_dual"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "Landcover_RockOutcrop",
+        "type": "symbol",
+        "paint": {
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgb(255,255,255)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "natural"
+                ],
+                "rock"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "geological"
+                ],
+                "outcrop"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 12,
+            "icon-image": "linz-topographic:rock_outcrop_large_pnt",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-offset": [
+                -3,
+                -6
+            ],
+            "text-anchor": "top",
+            "icon-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "Landcover-Swamp-Name",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(2, 46, 39, 1)",
+            "text-halo-blur": 0.5,
+            "text-translate": [
+                8,
+                0
+            ],
+            "text-halo-color": "rgba(252, 252, 252, 1)",
+            "text-halo-width": 0.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "swamp"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Light Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "center",
+            "text-justify": "center",
+            "icon-allow-overlap": true,
+            "text-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Swamp-Symbol",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(2, 46, 39, 1)",
+            "text-halo-blur": 0.5,
+            "text-translate": [
+                8,
+                0
+            ],
+            "text-halo-color": "rgba(252, 252, 252, 1)",
+            "text-halo-width": 0.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "swamp"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Light Italic"
+            ],
+            "text-size": 12,
+            "icon-image": "linz-topographic:swamp_pnt",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "left",
+            "text-justify": "right",
+            "icon-allow-overlap": true,
+            "text-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 14,
+        "minzoom": 13,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Swamp-pt",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "wetland"
+                ],
+                "swamp"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        6,
+                        0.4
+                    ],
+                    [
+                        10,
+                        0.75
+                    ],
+                    [
+                        15,
+                        1
+                    ],
+                    [
+                        19,
+                        1.3
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:swamp_pnt",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Housenumber",
+        "type": "symbol",
+        "paint": {
+            "icon-color": "rgba(0, 0, 0, 1)",
+            "text-color": "rgba(47, 47, 47, 1)",
+            "text-halo-blur": 20,
+            "text-halo-color": "rgba(255, 255, 255, 0.7)",
+            "text-halo-width": 0.25
+        },
+        "layout": {
+            "text-font": [
+                "Roboto Bold Italic"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        17,
+                        8
+                    ],
+                    [
+                        19,
+                        10
+                    ]
+                ]
+            },
+            "text-field": "{housenumber}",
+            "text-anchor": "bottom",
+            "text-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 17,
+        "source-layer": "addresses"
+    },
+    {
+        "id": "Waterway-Flume-Name",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(44, 44, 44, 1)",
+            "text-halo-color": "rgba(239, 239, 239, 0.80)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "flume"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 14,
+            "icon-image": "linz-topographic:flume_pnt_blue",
+            "text-field": "",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "center",
+            "text-offset": [
+                0,
+                0.015
+            ],
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-z-order": "auto",
+            "symbol-placement": "line-center",
+            "icon-pitch-alignment": "map",
+            "text-pitch-alignment": "auto",
+            "icon-rotation-alignment": "map",
+            "text-rotation-alignment": "auto"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Rapid-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(239, 239, 239, 0.80)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "stream"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "bottom",
+            "symbol-spacing": 750,
+            "symbol-placement": "line"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Water-Spring-Cold",
+        "type": "symbol",
+        "paint": {
+            "icon-color": "rgba(5, 0, 168, 1)",
+            "text-color": "rgba(20, 125, 228, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgb(255,255,255)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "natural"
+                ],
+                "spring"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "temp"
+                ],
+                "cold"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        0.3
+                    ],
+                    [
+                        15,
+                        0.7
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 12,
+            "icon-image": "linz-topographic:spring_cold_pnt",
+            "text-field": {
+                "stops": [
+                    [
+                        13,
+                        ""
+                    ],
+                    [
+                        16,
+                        "{name}"
+                    ],
+                    [
+                        17,
+                        "{name} (cold spring)"
+                    ]
+                ]
+            },
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                0.5
+            ],
+            "text-justify": "center",
+            "text-max-width": 8
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "Water-Spring-Hot",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(141, 0, 3, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgb(255,255,255)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "natural"
+                ],
+                "spring"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "temp"
+                ],
+                "hot"
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        12,
+                        0.4
+                    ],
+                    [
+                        15,
+                        0.7
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 12,
+            "icon-image": "linz-topographic:spring_hot_pnt",
+            "text-field": {
+                "stops": [
+                    [
+                        13,
+                        ""
+                    ],
+                    [
+                        14,
+                        "{name}"
+                    ],
+                    [
+                        16,
+                        "{name} (hot spring)"
+                    ]
+                ]
+            },
+            "visibility": "visible",
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                0.5
+            ],
+            "text-max-width": 8
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "pois"
+    },
+    {
+        "id": "All-Highway-Labels-three",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(255, 255, 255, 1)",
+            "icon-translate-anchor": "map",
+            "text-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "hway_num"
+                ],
+                [
+                    "literal",
+                    [
+                        "25A",
+                        "20A",
+                        "20B",
+                        "29A",
+                        "30A",
+                        "74A",
+                        "67A"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        8,
+                        1.2
+                    ],
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        15,
+                        1.7
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        8,
+                        9
+                    ],
+                    [
+                        11,
+                        10
+                    ],
+                    [
+                        15,
+                        14
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:highway_pnt_wide",
+            "text-field": "{hway_num}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "icon-offset": [
+                0,
+                1
+            ],
+            "icon-rotate": 0,
+            "icon-padding": 2,
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-spacing": {
+                "stops": [
+                    [
+                        6,
+                        500
+                    ],
+                    [
+                        13,
+                        400
+                    ]
+                ]
+            },
+            "symbol-placement": "line",
+            "icon-keep-upright": false,
+            "text-keep-upright": true,
+            "icon-pitch-alignment": "viewport",
+            "text-pitch-alignment": "viewport",
+            "icon-text-fit-padding": [
+                1,
+                4,
+                3,
+                3
+            ],
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "All-Highway-Labels-standard",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(255, 255, 255, 1)",
+            "icon-translate-anchor": "map",
+            "text-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "hway_num"
+            ],
+            [
+                "!",
+                [
+                    "in",
+                    [
+                        "get",
+                        "hway_num"
+                    ],
+                    [
+                        "literal",
+                        [
+                            "6,94",
+                            "2,50",
+                            "1,3",
+                            "12,15",
+                            "14,15",
+                            "6,96",
+                            "25A",
+                            "20A",
+                            "20B",
+                            "29A",
+                            "30A",
+                            "74A",
+                            "67A"
+                        ]
+                    ]
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        8,
+                        1.2
+                    ],
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        15,
+                        1.7
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        8,
+                        9
+                    ],
+                    [
+                        11,
+                        10
+                    ],
+                    [
+                        15,
+                        14
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:highway_pnt_standard",
+            "text-field": "{hway_num}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "icon-offset": [
+                0,
+                1
+            ],
+            "icon-rotate": 0,
+            "icon-padding": 2,
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-spacing": {
+                "stops": [
+                    [
+                        6,
+                        500
+                    ],
+                    [
+                        13,
+                        400
+                    ]
+                ]
+            },
+            "symbol-placement": "line",
+            "icon-keep-upright": false,
+            "text-keep-upright": true,
+            "icon-pitch-alignment": "viewport",
+            "text-pitch-alignment": "viewport",
+            "icon-text-fit-padding": [
+                1,
+                4,
+                3,
+                3
+            ],
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "All-Road-Labels",
+        "type": "symbol",
+        "paint": {
+            "text-opacity": 0.9,
+            "text-halo-color": "rgba(243, 243, 242, 0.9)",
+            "text-halo-width": 2.5
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "name"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "subclass"
+                ],
+                "foot_route_closed"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "subclass"
+                ],
+                "foot_closed"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "aerodrome"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "raceway"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        11
+                    ],
+                    [
+                        18,
+                        10
+                    ],
+                    [
+                        19,
+                        30
+                    ],
+                    [
+                        22,
+                        140
+                    ]
+                ]
+            },
+            "text-field": "{name}",
+            "visibility": "visible",
+            "text-anchor": "center",
+            "text-justify": "center",
+            "icon-text-fit": "both",
+            "symbol-spacing": 250,
+            "text-transform": "none",
+            "symbol-placement": "line",
+            "icon-pitch-alignment": "auto",
+            "icon-ignore-placement": false
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Ferry-Symbol",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "ferry"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.5,
+            "text-font": [],
+            "icon-image": "linz-topographic:star_pnt_fill",
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-z-order": "auto",
+            "symbol-placement": "line-center",
+            "icon-allow-overlap": false,
+            "text-pitch-alignment": "auto",
+            "icon-ignore-placement": false,
+            "icon-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "ferries"
+    },
+    {
+        "id": "Transport-Tunnel-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(80, 75, 75, 1)",
+            "text-halo-color": "rgba(230, 230, 230, 0.5)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tunnel"
+                ],
+                true
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Roboto Black"
+            ],
+            "text-size": 10,
+            "text-field": "tunnel",
+            "visibility": "visible",
+            "text-offset": {
+                "stops": [
+                    [
+                        15,
+                        [
+                            0,
+                            -1.25
+                        ]
+                    ],
+                    [
+                        17,
+                        [
+                            0,
+                            -1.75
+                        ]
+                    ],
+                    [
+                        19,
+                        [
+                            0,
+                            -6
+                        ]
+                    ],
+                    [
+                        20,
+                        [
+                            0,
+                            -9
+                        ]
+                    ],
+                    [
+                        22,
+                        [
+                            0,
+                            -16
+                        ]
+                    ]
+                ]
+            },
+            "symbol-spacing": 100,
+            "symbol-placement": "line"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Aeroway-Aerodrome-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(129, 123, 123, 1)",
+            "icon-opacity": 0.8,
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "aerodrome"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1.2,
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:airport_airport_pnt_fill",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "bottom",
+            "icon-offset": [
+                0,
+                0
+            ],
+            "text-anchor": "top",
+            "text-justify": "center",
+            "text-padding": 2,
+            "icon-text-fit": "none",
+            "symbol-spacing": 250,
+            "text-max-width": 5,
+            "text-allow-overlap": false,
+            "icon-pitch-alignment": "viewport",
+            "text-pitch-alignment": "auto",
+            "icon-ignore-placement": false,
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "auto"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "public_transport"
+    },
+    {
+        "id": "Aeroway-Runway-Grass-Label",
+        "type": "symbol",
+        "paint": {
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(246, 246, 246, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "runway"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "surface"
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Roboto Light"
+            ],
+            "text-size": 10,
+            "text-field": "airstrip",
+            "text-anchor": "left",
+            "text-justify": "left"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "Aeroway-Helipads",
+        "type": "symbol",
+        "paint": {
+            "icon-opacity": 0.8
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "helipad"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1.25,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "icon-image": "linz-topographic:helipad_pnt_fill"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "public_transport"
+    },
+    {
+        "id": "All-Reef-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(239, 239, 239, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "reef"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "text-anchor": "center",
+            "text-offset": [
+                0,
+                1
+            ],
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "All-Lake-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(239, 239, 239, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lake"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "All-Canal-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(239, 239, 239, 0.80)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "bottom",
+            "text-justify": "center",
+            "symbol-spacing": 1000,
+            "text-max-angle": 35,
+            "symbol-placement": "line",
+            "icon-allow-overlap": false,
+            "text-allow-overlap": true,
+            "icon-ignore-placement": false,
+            "text-ignore-placement": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "All-River-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(239, 239, 239, 0.80)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "bottom",
+            "text-justify": "center",
+            "symbol-spacing": 1000,
+            "text-max-angle": 35,
+            "symbol-placement": "line",
+            "icon-allow-overlap": false,
+            "text-allow-overlap": true,
+            "icon-ignore-placement": false,
+            "text-ignore-placement": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "All-Waterway-Canal-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(239, 239, 239, 0.80)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "text-anchor": "bottom",
+            "symbol-spacing": 1000,
+            "text-max-angle": 35,
+            "symbol-placement": "line",
+            "text-allow-overlap": true,
+            "text-ignore-placement": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "All-Waterway-Drain-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(239, 239, 239, 0.80)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "drain"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "text-anchor": "bottom",
+            "symbol-spacing": 1000,
+            "text-max-angle": 35,
+            "symbol-placement": "line",
+            "text-allow-overlap": true,
+            "text-ignore-placement": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "All-Waterway-River-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(239, 239, 239, 0.80)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "text-anchor": "bottom",
+            "symbol-spacing": 1000,
+            "text-max-angle": 35,
+            "symbol-placement": "line",
+            "text-allow-overlap": true,
+            "text-ignore-placement": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Waterfall-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(239, 239, 239, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "waterfall"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 13,
+            "text-field": "{name} {height}m",
+            "text-anchor": "bottom",
+            "text-max-width": 3,
+            "symbol-placement": "line",
+            "text-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Waterfall-Pt-Ln",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "waterway"
+                ],
+                "waterfall"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1.5,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        12,
+                        8
+                    ],
+                    [
+                        16,
+                        14
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:rapid_pnt",
+            "text-field": "",
+            "visibility": "visible",
+            "text-anchor": "bottom",
+            "icon-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 14,
+        "minzoom": 12,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Waterway-Waterfall-Pt",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(232, 232, 232, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "waterway"
+                ],
+                "waterfall"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1.5,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        12,
+                        8
+                    ],
+                    [
+                        16,
+                        12
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:waterfall_pnt",
+            "text-field": "{name} {height}m",
+            "visibility": "visible",
+            "text-anchor": "top",
+            "text-offset": [
+                0,
+                1
+            ],
+            "text-rotate": 0,
+            "text-max-width": 3,
+            "icon-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 14,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Place-Label-Lake",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "lake"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 11,
+        "minzoom": 7,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Bay",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "any",
+            [
+                "in",
+                [
+                    "get",
+                    "natural"
+                ],
+                [
+                    "literal",
+                    [
+                        "bay"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "water"
+                ],
+                [
+                    "literal",
+                    [
+                        "bay",
+                        "lagoon"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Medium"
+            ],
+            "text-size": 10,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Symbol-Peak-12",
+        "type": "symbol",
+        "paint": {
+            "icon-color": "rgba(61, 162, 86, 1)",
+            "text-color": "rgba(41, 90, 55, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 0.5)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "natural"
+                ],
+                [
+                    "literal",
+                    [
+                        "peak",
+                        "cape",
+                        "peninsula"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.35,
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:triangle_pnt_fill",
+            "text-field": "",
+            "visibility": "visible",
+            "text-anchor": "left",
+            "text-offset": [
+                0.5,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 12,
+        "minzoom": 10,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Peak-16",
+        "type": "symbol",
+        "paint": {
+            "icon-color": "rgba(61, 162, 86, 1)",
+            "text-color": "rgba(41, 90, 55, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "natural"
+                ],
+                [
+                    "literal",
+                    [
+                        "peak",
+                        "cape",
+                        "peninsula"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.5,
+            "text-font": [
+                "Open Sans Medium"
+            ],
+            "text-size": 11,
+            "icon-image": "linz-topographic:triangle_pnt_fill",
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-anchor": "left",
+            "text-offset": [
+                0.5,
+                0
+            ],
+            "text-justify": "left",
+            "text-optional": true,
+            "text-max-width": 4,
+            "text-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 16,
+        "minzoom": 12,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Suburb",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "suburb"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 10,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Locality",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "locality"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Medium"
+            ],
+            "text-size": 11,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 9,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Town",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "town"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Medium"
+            ],
+            "text-size": 12,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 8,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-City-14",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "city"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6,
+                        7,
+                        8
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 15,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "symbol-z-order": "viewport-y",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 14,
+        "minzoom": 7,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Island-12",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "island"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 12,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 12,
+        "minzoom": 8,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Sea-5",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 0.8
+        },
+        "filter": [
+            "any",
+            [
+                "in",
+                [
+                    "get",
+                    "water"
+                ],
+                [
+                    "literal",
+                    [
+                        "sea"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 6,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Sea",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 0.8
+        },
+        "filter": [
+            "any",
+            [
+                "in",
+                [
+                    "get",
+                    "water"
+                ],
+                [
+                    "literal",
+                    [
+                        "seamount",
+                        "searidge",
+                        "seachannel",
+                        "seacanyon"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 5,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Lake-7",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "lake"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        3,
+                        4
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 7,
+        "minzoom": 6,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-City-7",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "city"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 15,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4,
+            "text-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 7,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Island-8",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "place"
+                ],
+                [
+                    "literal",
+                    [
+                        "island",
+                        "archipelago"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        3,
+                        4
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 14,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 8,
+        "minzoom": 6,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Island-6",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "place"
+                ],
+                [
+                    "literal",
+                    [
+                        "island",
+                        "archipelago"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 14,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 7
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 6,
+        "minzoom": 5,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Peak-11",
+        "type": "symbol",
+        "paint": {
+            "icon-color": "rgba(61, 162, 86, 1)",
+            "text-color": "rgba(41, 90, 55, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "natural"
+                ],
+                [
+                    "literal",
+                    [
+                        "peak",
+                        "cape",
+                        "peninsula"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6,
+                        8
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.5,
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 11,
+            "icon-image": "linz-topographic:triangle_pnt_fill",
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-anchor": "left",
+            "text-offset": [
+                0.5,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 4,
+            "text-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 14,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Island-4",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 0, 0, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "place"
+                ],
+                [
+                    "literal",
+                    [
+                        "archipelago"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        2
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 14,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 5,
+        "minzoom": 0,
+        "source-layer": "place_labels"
+    }
+]

--- a/LINZ_Vector_Map_Styles/LINZ_Topolite_V2_Hillshade.migrated.json
+++ b/LINZ_Vector_Map_Styles/LINZ_Topolite_V2_Hillshade.migrated.json
@@ -1,0 +1,5984 @@
+[
+    {
+        "id": "Background",
+        "type": "background",
+        "paint": {
+            "background-color": "rgba(184, 220, 242, 1)"
+        },
+        "layout": {
+            "visibility": "visible"
+        },
+        "minzoom": 0
+    },
+    {
+        "id": "Landcover-Sand",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(220, 205, 177, 0.3)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "sand"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Mangrove",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 199, 155, 0.3)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "mangrove"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Coastline2",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        1,
+                        "rgba(234, 233, 229, 1)"
+                    ],
+                    [
+                        10,
+                        "#FCFBF7"
+                    ]
+                ]
+            },
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "all"
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "boundaries"
+    },
+    {
+        "id": "Vegetation-Scatteredscrub",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(204, 222, 195, 0.4)",
+            "fill-antialias": false,
+            "fill-outline-color": "rgba(210, 210, 210, 0.1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "scrub"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "distribution"
+                ],
+                "scattered"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Scrub",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(199, 228, 183, 0.4)",
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(255, 255, 255, 0.1)"
+                    ],
+                    [
+                        10,
+                        "rgba(255, 255, 255, 0.1)"
+                    ],
+                    [
+                        19,
+                        "rgba(255, 255, 255, 0.1)"
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "scrub"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "distribution"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Exotic",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(157, 201, 139, 0.4)"
+                    ],
+                    [
+                        11,
+                        "rgba(194, 222, 171, 0.4)"
+                    ]
+                ]
+            },
+            "fill-outline-color": "rgba(210, 210, 210, 0)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tree"
+                ],
+                "exotic"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "landuse"
+                ],
+                "wood"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "land"
+    },
+    {
+        "id": "Vegetation-Native",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(153, 191, 140, 0.4)"
+                    ],
+                    [
+                        9,
+                        "rgba(150, 185, 136, 0.4)"
+                    ],
+                    [
+                        11,
+                        "rgba(144, 183, 125, 0.4)"
+                    ],
+                    [
+                        14,
+                        "rgba(154, 191, 133, 0.4)"
+                    ]
+                ]
+            },
+            "fill-outline-color": "rgba(210, 210, 210, 0)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tree"
+                ],
+                "native"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Ice",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(255, 255, 255, 0.44)",
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        8,
+                        "rgba(255, 255, 255, 0.01)"
+                    ],
+                    [
+                        10,
+                        "rgba(211, 249, 249, 0.5)"
+                    ],
+                    [
+                        11,
+                        "rgba(57, 158, 158, 0.5)"
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "ice"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Orchard",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(27, 127, 36, 0.1)",
+            "fill-outline-color": "rgba(255, 255, 255, 1)",
+            "fill-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "orchard"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Vineyard",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(27, 127, 36, 0.2)",
+            "fill-antialias": false,
+            "fill-outline-color": "rgba(255, 255, 255, 1)",
+            "fill-translate-anchor": "viewport"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "vineyard"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Swamp-Fill",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(205, 232, 230, 1)"
+                    ],
+                    [
+                        14,
+                        "rgba(224, 236, 238, 1)"
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "swamp"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Mine-Quarry-Poly",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(205, 205, 205, 1)",
+            "fill-opacity": 0.5
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "mine"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "quarry"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-Swamp-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(0, 140, 204, 0.1)"
+                    ],
+                    [
+                        11,
+                        "rgba(0, 140, 204, 0.8)"
+                    ]
+                ]
+            },
+            "line-width": 0.5,
+            "line-dasharray": [
+                6,
+                6,
+                4,
+                4
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "swamp"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "land"
+    },
+    {
+        "id": "Contours-All",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(232, 184, 77, 0.75)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        0.3
+                    ],
+                    [
+                        16,
+                        0.2
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "!",
+                [
+                    "has",
+                    "designated"
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "type"
+                ],
+                "index"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "nat_form"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 16,
+        "minzoom": 9,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Contours-Designated",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(232, 184, 77, 0.75)",
+            "line-width": 0.4,
+            "line-dasharray": [
+                30,
+                30
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "designated"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 16,
+        "minzoom": 9,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Contours-Index",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(232, 184, 77, 0.5)"
+                    ],
+                    [
+                        15,
+                        "rgba(232, 184, 77, 0.5)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        15,
+                        1.2
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "type"
+                ],
+                "index"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 16,
+        "minzoom": 11,
+        "source-layer": "contours"
+    },
+    {
+        "id": "Contours-Natural",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(232, 184, 77, 0.5)",
+            "line-width": 0.6,
+            "line-dasharray": [
+                30,
+                10,
+                10,
+                10
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "nat_form"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 16,
+        "minzoom": 9,
+        "source-layer": "contours"
+    },
+    {
+        "id": "hillshade",
+        "type": "hillshade",
+        "source": "__terrain__",
+        "layout": {
+            "visibility": "visible"
+        },
+        "paint": {
+            "hillshade-accent-color": ["interpolate", ["linear"], ["zoom"],
+                0, "rgba(100, 100, 100, 0.400)",
+                3, "rgba(100, 100, 100, 0.400)",
+                9, "rgba(100, 100, 100, 0.333)",
+                11, "rgba(100, 100, 100, 0.267)",
+                14, "rgba(100, 100, 100, 0.400)",
+                17, "rgba(100, 100, 100, 0.600)"
+            ],
+            "hillshade-exaggeration": 0.4,
+            "hillshade-highlight-color": ["interpolate", ["linear"], ["zoom"],
+                0, "rgba(225, 229, 224, 0.800)",
+                3, "rgba(225, 229, 224, 0.800)",
+                9, "rgba(225, 229, 224, 0.333)",
+                11, "rgba(225, 229, 224, 0.0667)",
+                14, "rgba(225, 229, 224, 0.0667)",
+                17, "rgba(225, 229, 224, 0.267)"
+            ],
+            "hillshade-illumination-anchor": "map",
+            "hillshade-illumination-direction": 315,
+            "hillshade-shadow-color": ["interpolate", ["linear"], ["zoom"],
+                0, "rgba(12, 12, 12, 1.00)",
+                3, "rgba(12, 12, 12, 0.800)",
+                9, "rgba(12, 12, 12, 0.667)",
+                11, "rgba(12, 12, 12, 0.533)",
+                14, "rgba(12, 12, 12, 0.400)",
+                17, "rgba(12, 12, 12, 0.600)"
+            ]
+        }
+    },
+    {
+        "id": "Aeroway-Airport",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(224, 224, 224, 0.7)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "aerodrome"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "Aeroway-Airstrip-Sealed",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(209, 209, 209, 0.5)",
+            "fill-antialias": false
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "runway"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "sealed"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "Aeroway-Runway-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(125, 125, 125, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        2,
+                        1
+                    ],
+                    [
+                        10,
+                        0.7
+                    ],
+                    [
+                        19,
+                        0.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "runway"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "sealed"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "Aeroway-Airstrip-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(125, 125, 125, 1)",
+            "line-dasharray": [
+                5,
+                5
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "runway"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "surface"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "Water-Polys-Outline",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(184, 220, 242, 1)"
+                    ],
+                    [
+                        13,
+                        "rgba(0, 140, 204, 0.3)"
+                    ],
+                    [
+                        19,
+                        "rgba(0, 140, 204, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        9,
+                        1
+                    ],
+                    [
+                        15,
+                        2.5
+                    ]
+                ]
+            },
+            "line-offset": 0
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lake"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lagoon"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Canal-Poly-Named",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(204, 232, 245, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(184, 220, 242, 1)"
+                    ],
+                    [
+                        13,
+                        "rgba(0, 140, 204, 0.3)"
+                    ],
+                    [
+                        19,
+                        "rgba(0, 140, 204, 1)"
+                    ]
+                ]
+            },
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 9,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Lagoon",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lagoon"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Lake",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lake"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Lake-Named",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lake"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-River-Poly-Named",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Canal-Poly",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 21,
+        "minzoom": 13,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-River-Poly",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-opacity": 1,
+            "fill-antialias": true,
+            "fill-translate-anchor": "map"
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 21,
+        "minzoom": 13,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Water-Reef",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(0, 140, 204, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        2,
+                        0.5
+                    ],
+                    [
+                        10,
+                        1
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                12,
+                2
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "reef"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Waterway-Canal-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        11,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.75)"
+                    ],
+                    [
+                        20,
+                        "rgba(0, 140, 204, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        13,
+                        0.75
+                    ],
+                    [
+                        18,
+                        0.5
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "canal"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 21,
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-Drain-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        11,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.75)"
+                    ],
+                    [
+                        20,
+                        "rgba(0, 140, 204, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        13,
+                        0.75
+                    ],
+                    [
+                        18,
+                        0.5
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "drain"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 21,
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Water-Dry-Dock-ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(73, 73, 73, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.75
+                    ],
+                    [
+                        14,
+                        1.5
+                    ],
+                    [
+                        18,
+                        2
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "dry_dock"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Water-River-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.75)"
+                    ],
+                    [
+                        20,
+                        "rgba(0, 140, 204, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        1
+                    ],
+                    [
+                        18,
+                        0.75
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 21,
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Water-River-Ln-Named",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        9,
+                        "rgba(125, 198, 215, 0.01)"
+                    ],
+                    [
+                        10,
+                        "rgba(125, 198, 215, 0.75)"
+                    ],
+                    [
+                        11,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        12,
+                        "rgba(167, 209, 232, 0.75)"
+                    ],
+                    [
+                        13,
+                        "rgba(76, 147, 226, 0.75)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        13,
+                        1
+                    ]
+                ]
+            },
+            "line-opacity": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Waterway-WaterRace",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        13,
+                        "rgba(0, 140, 204, 0.3)"
+                    ],
+                    [
+                        19,
+                        "rgba(0, 140, 204, 1)"
+                    ]
+                ]
+            },
+            "line-width": 0.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "water_race"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Landuse-Landfill",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(143, 104, 55, 0.45)",
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "landfill"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Pond",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-outline-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(184, 220, 242, 1)"
+                    ],
+                    [
+                        13,
+                        "rgba(0, 140, 204, 0.3)"
+                    ],
+                    [
+                        19,
+                        "rgba(0, 140, 204, 1)"
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "pond"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landuse-Reservoir-Covered",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(148, 148, 148, 1)",
+            "fill-outline-color": "rgba(18, 18, 18, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "reservoir"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lid_type"
+                ],
+                "covered"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Landuse-Reservoir-Empty",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(184, 220, 242, 1)",
+            "fill-outline-color": "rgba(18, 18, 18, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "reservoir"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "lid_type"
+                ],
+                "covered"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Landuse-Residential",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        1,
+                        "rgba(204, 204, 204, 1)"
+                    ],
+                    [
+                        10,
+                        "rgba(204, 204, 204, 0.95)"
+                    ],
+                    [
+                        13,
+                        "rgba(204, 204, 204, 0.6)"
+                    ],
+                    [
+                        15,
+                        "rgba(232, 232, 232, 0.4)"
+                    ],
+                    [
+                        22,
+                        "rgba(232, 232, 232, 0.1)"
+                    ]
+                ]
+            },
+            "fill-outline-color": "rgba(164, 164, 164, 0.01)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "residential"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "land"
+    },
+    {
+        "id": "Landcover-GolfCourse",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(121, 195, 128, 0.2)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "golf_course"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Coastline-Ln-2",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        1,
+                        "rgba(9, 132, 186, 0.5)"
+                    ],
+                    [
+                        6,
+                        "rgba(9, 132, 186, 0.5)"
+                    ],
+                    [
+                        10,
+                        "rgba(27, 152, 193, 0.5)"
+                    ],
+                    [
+                        16,
+                        "rgba(34, 164, 212, 0.5)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        6,
+                        0.5
+                    ],
+                    [
+                        10,
+                        0.55
+                    ],
+                    [
+                        15,
+                        1.25
+                    ],
+                    [
+                        20,
+                        3.5
+                    ]
+                ]
+            },
+            "line-translate-anchor": "map"
+        },
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "boundaries"
+    },
+    {
+        "id": "Poi-FishFarm",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgb(112,172,242)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "fish_farm"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-SportsField",
+        "type": "fill",
+        "paint": {
+            "fill-color": "rgba(121, 195, 128, 0.2)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "sports_field"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "sites"
+    },
+    {
+        "id": "Poi-Storage-Tank-Empty",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(240, 240, 240, 0.85)"
+                    ],
+                    [
+                        10,
+                        "rgba(240, 240, 240, 0.85)"
+                    ]
+                ]
+            },
+            "fill-opacity": {
+                "stops": [
+                    [
+                        14,
+                        1
+                    ],
+                    [
+                        20,
+                        0.2
+                    ]
+                ]
+            },
+            "fill-antialias": true,
+            "fill-outline-color": "rgba(67, 67, 67, 1)"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "storage_tank"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "store_item"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 0,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Poi-Siphon",
+        "type": "fill",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "siphon"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Tank-Pt-Fill-Empty",
+        "type": "circle",
+        "paint": {
+            "circle-color": "rgba(255, 255, 255, 1)",
+            "circle-radius": {
+                "stops": [
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        15,
+                        3.5
+                    ]
+                ]
+            },
+            "circle-opacity": {
+                "stops": [
+                    [
+                        14,
+                        1
+                    ],
+                    [
+                        20,
+                        0.2
+                    ]
+                ]
+            },
+            "circle-pitch-alignment": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "building"
+                ],
+                "storage_tank"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "store_item"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "pois"
+    },
+    {
+        "id": "Poi-Dredge-Tailing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(55, 55, 55, 1)",
+            "line-width": 10,
+            "line-opacity": 0.9,
+            "line-pattern": "linz-topographic:dredge_tailing_pnt"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "dredge_tailing"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Slipway-Symbol-Dash",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(64, 64, 64, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        16,
+                        4
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "slipway"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Poi-Slipway-Symbol-Line",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(64, 64, 64, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        4
+                    ],
+                    [
+                        16,
+                        18
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                0.15,
+                0.4
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "slipway"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "source-layer": "land"
+    },
+    {
+        "id": "Parcels-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        8,
+                        "rgba(203, 203, 203, 1)"
+                    ],
+                    [
+                        16,
+                        "rgba(204, 204, 204, 1)"
+                    ],
+                    [
+                        24,
+                        "rgba(170, 170, 170, 1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        0.2
+                    ],
+                    [
+                        16,
+                        0.75
+                    ],
+                    [
+                        24,
+                        1.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "!",
+                [
+                    "==",
+                    [
+                        "get",
+                        "parcel_intent"
+                    ],
+                    "Road"
+                ]
+            ],
+            [
+                "!",
+                [
+                    "==",
+                    [
+                        "get",
+                        "parcel_intent"
+                    ],
+                    "Hydro"
+                ]
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "parcel_boundaries"
+    },
+    {
+        "id": "Buildings",
+        "type": "fill",
+        "paint": {
+            "fill-color": {
+                "stops": [
+                    [
+                        15,
+                        "#DBDBD9"
+                    ],
+                    [
+                        17,
+                        "#DBDBD9"
+                    ],
+                    [
+                        18,
+                        "#DBDBD9"
+                    ],
+                    [
+                        19,
+                        "#DBDBD9"
+                    ]
+                ]
+            },
+            "fill-opacity": 1,
+            "fill-antialias": true
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "building"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 16,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Buildings-Outline",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(152, 145, 145,0.6)",
+            "line-width": {
+                "stops": [
+                    [
+                        17,
+                        0.5
+                    ],
+                    [
+                        24,
+                        1
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "building"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 16,
+        "source-layer": "buildings"
+    },
+    {
+        "id": "Transport-Bridge-Foot",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(78, 78, 78, 0.3)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        15,
+                        4
+                    ],
+                    [
+                        19,
+                        6
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "bridge"
+                ],
+                true
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "use_1"
+                ],
+                "foot traffic"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-FootTracks-Shadow",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(231, 231, 231, 0.4)",
+            "line-width": {
+                "stops": [
+                    [
+                        13,
+                        1.5
+                    ],
+                    [
+                        15,
+                        2.5
+                    ],
+                    [
+                        19,
+                        5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "foot"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-VehicleTracks-Shadow",
+        "type": "line",
+        "paint": {
+            "line-blur": 0.75,
+            "line-color": "rgba(231, 231, 231, 0.4)",
+            "line-width": {
+                "base": 1,
+                "stops": [
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        19,
+                        5
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                8
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "track"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_use"
+                ],
+                "vehicle"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1Casing",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(78, 78, 78, .1)"
+                    ],
+                    [
+                        17,
+                        "rgba(78, 78, 78, .1)"
+                    ],
+                    [
+                        18,
+                        "rgba(96, 96, 96, .1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.5
+                    ],
+                    [
+                        12,
+                        3
+                    ],
+                    [
+                        13,
+                        4.5
+                    ],
+                    [
+                        15,
+                        5.5
+                    ],
+                    [
+                        18,
+                        11
+                    ],
+                    [
+                        19,
+                        40
+                    ],
+                    [
+                        22,
+                        200
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 18,
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2Casing",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "rgba(78, 78, 78, 0.1)"
+                    ],
+                    [
+                        17,
+                        "rgba(78, 78, 78, 0.1)"
+                    ],
+                    [
+                        18,
+                        "rgba(96, 96, 96, 0.1)"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        11,
+                        3.5
+                    ],
+                    [
+                        12,
+                        3.9
+                    ],
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        10
+                    ],
+                    [
+                        18,
+                        16
+                    ],
+                    [
+                        19,
+                        50
+                    ],
+                    [
+                        22,
+                        200
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8
+                    ]
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 18,
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1UnMetalled",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 254, 252, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        12,
+                        1
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        18,
+                        8
+                    ],
+                    [
+                        19,
+                        35
+                    ],
+                    [
+                        22,
+                        180
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "unmetalled"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1Metalled-White",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 254, 252, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        11,
+                        1
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        18,
+                        8
+                    ],
+                    [
+                        19,
+                        35
+                    ],
+                    [
+                        22,
+                        180
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "metalled"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1-UnderCons",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(96, 96, 96, 0.1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        11,
+                        1
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        18,
+                        8
+                    ],
+                    [
+                        19,
+                        35
+                    ],
+                    [
+                        22,
+                        180
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                1,
+                5
+            ]
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "status"
+                ],
+                "under construction"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1Sealed",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        10,
+                        "#fff"
+                    ],
+                    [
+                        17,
+                        "#fff"
+                    ],
+                    [
+                        19,
+                        "#fff"
+                    ]
+                ]
+            },
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        11,
+                        1
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        3
+                    ],
+                    [
+                        18,
+                        8
+                    ],
+                    [
+                        19,
+                        35
+                    ],
+                    [
+                        22,
+                        180
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "sealed"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2UnMetalled",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 255, 255, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.35
+                    ],
+                    [
+                        11,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        16,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "unmetalled"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "staus"
+                ],
+                "under construction"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2Metalled-White",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 255, 255, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.35
+                    ],
+                    [
+                        11,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        15,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "metalled"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2UnderContruction",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(96, 96, 96, 0.1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.35
+                    ],
+                    [
+                        11,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        16,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            },
+            "line-dasharray": [
+                1,
+                5
+            ],
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "status"
+                ],
+                "under construction"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2+Sealed",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(255, 255, 255, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1
+                    ],
+                    [
+                        11,
+                        1
+                    ],
+                    [
+                        12,
+                        1.75
+                    ],
+                    [
+                        13,
+                        4
+                    ],
+                    [
+                        15,
+                        7.5
+                    ],
+                    [
+                        18,
+                        14
+                    ],
+                    [
+                        19,
+                        55
+                    ],
+                    [
+                        22,
+                        380
+                    ]
+                ]
+            },
+            "line-gap-width": 0,
+            "line-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "surface"
+                ],
+                "sealed"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Railway-Siding",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(67, 61, 61, 0.65)",
+            "line-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rail"
+            ],
+            [
+                "has",
+                "rway_use"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Railway-Single",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(67, 61, 61, 0.65)",
+            "line-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rail"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_type"
+                ],
+                "single"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "rway_use"
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Railway-Multiple",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(67, 61, 61, 0.65)",
+            "line-width": {
+                "stops": [
+                    [
+                        11,
+                        2.5
+                    ],
+                    [
+                        19,
+                        4
+                    ],
+                    [
+                        20,
+                        4
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rail"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "track_type"
+                ],
+                "multiple"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Railway-High",
+        "type": "line",
+        "paint": {
+            "line-color": {
+                "stops": [
+                    [
+                        8,
+                        "rgba(158, 153, 153, 1)"
+                    ],
+                    [
+                        10,
+                        "rgba(96, 90, 90, 0.95)"
+                    ]
+                ]
+            },
+            "line-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "rail"
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 11,
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Roads-9-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        1,
+                        0
+                    ],
+                    [
+                        6,
+                        0.5
+                    ],
+                    [
+                        7,
+                        1
+                    ],
+                    [
+                        8,
+                        3.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 9,
+        "minzoom": 0,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Roads-9",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(210, 162, 84, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        1,
+                        0.1
+                    ],
+                    [
+                        5,
+                        0.4
+                    ],
+                    [
+                        7,
+                        1.4
+                    ],
+                    [
+                        8,
+                        2.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 9,
+        "minzoom": 0,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1HWY-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        1.5
+                    ],
+                    [
+                        10,
+                        1.75
+                    ],
+                    [
+                        12,
+                        3.25
+                    ],
+                    [
+                        13,
+                        5
+                    ],
+                    [
+                        15,
+                        7
+                    ],
+                    [
+                        18,
+                        13
+                    ],
+                    [
+                        19,
+                        50
+                    ],
+                    [
+                        22,
+                        220
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        1
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "round",
+            "visibility": "none"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2HWY-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 0.8)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        3.25
+                    ],
+                    [
+                        10,
+                        4.5
+                    ],
+                    [
+                        12,
+                        6.5
+                    ],
+                    [
+                        13,
+                        8.5
+                    ],
+                    [
+                        15,
+                        12
+                    ],
+                    [
+                        18,
+                        19
+                    ],
+                    [
+                        19,
+                        70
+                    ],
+                    [
+                        22,
+                        450
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "round",
+            "visibility": "none"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-HWY-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        3.5
+                    ],
+                    [
+                        10,
+                        5
+                    ],
+                    [
+                        12,
+                        7.5
+                    ],
+                    [
+                        13,
+                        9
+                    ],
+                    [
+                        15,
+                        13
+                    ],
+                    [
+                        18,
+                        21
+                    ],
+                    [
+                        19,
+                        80
+                    ],
+                    [
+                        22,
+                        470
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "round",
+            "visibility": "none"
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 13,
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2HWY-Casing-14",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        3.25
+                    ],
+                    [
+                        10,
+                        4.5
+                    ],
+                    [
+                        12,
+                        6.5
+                    ],
+                    [
+                        13,
+                        8.5
+                    ],
+                    [
+                        15,
+                        12
+                    ],
+                    [
+                        18,
+                        19
+                    ],
+                    [
+                        19,
+                        70
+                    ],
+                    [
+                        22,
+                        450
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1HWY-Casing-14",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        1.5
+                    ],
+                    [
+                        10,
+                        1.75
+                    ],
+                    [
+                        12,
+                        3.25
+                    ],
+                    [
+                        13,
+                        5
+                    ],
+                    [
+                        15,
+                        7
+                    ],
+                    [
+                        18,
+                        13
+                    ],
+                    [
+                        19,
+                        50
+                    ],
+                    [
+                        22,
+                        220
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        1
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-HWY-Casing-14",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(120, 120, 120, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        3.5
+                    ],
+                    [
+                        10,
+                        5
+                    ],
+                    [
+                        12,
+                        7.5
+                    ],
+                    [
+                        13,
+                        9
+                    ],
+                    [
+                        15,
+                        13
+                    ],
+                    [
+                        18,
+                        21
+                    ],
+                    [
+                        19,
+                        80
+                    ],
+                    [
+                        22,
+                        470
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-2HWY",
+        "type": "line",
+        "paint": {
+            "line-blur": 0,
+            "line-color": "rgba(240, 164, 82, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        1.35
+                    ],
+                    [
+                        10,
+                        1.75
+                    ],
+                    [
+                        11,
+                        2.25
+                    ],
+                    [
+                        13,
+                        5.25
+                    ],
+                    [
+                        15,
+                        8.5
+                    ],
+                    [
+                        18,
+                        15
+                    ],
+                    [
+                        19,
+                        60
+                    ],
+                    [
+                        22,
+                        420
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "round",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-1HWY",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(240, 164, 82, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        0.75
+                    ],
+                    [
+                        10,
+                        1
+                    ],
+                    [
+                        11,
+                        1.25
+                    ],
+                    [
+                        13,
+                        2.5
+                    ],
+                    [
+                        15,
+                        4
+                    ],
+                    [
+                        18,
+                        9
+                    ],
+                    [
+                        19,
+                        40
+                    ],
+                    [
+                        22,
+                        200
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "==",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-HWY",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(240, 164, 82, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        8,
+                        1.5
+                    ],
+                    [
+                        10,
+                        2
+                    ],
+                    [
+                        11,
+                        3
+                    ],
+                    [
+                        13,
+                        5.75
+                    ],
+                    [
+                        15,
+                        9
+                    ],
+                    [
+                        18,
+                        16.5
+                    ],
+                    [
+                        19,
+                        70
+                    ],
+                    [
+                        22,
+                        440
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "motorway"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                [
+                    "literal",
+                    [
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "round",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Bridge-VT-Casing",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(168, 168, 168, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        6
+                    ],
+                    [
+                        15,
+                        8
+                    ],
+                    [
+                        18,
+                        18
+                    ],
+                    [
+                        19,
+                        75
+                    ],
+                    [
+                        22,
+                        450
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "bridge"
+                ],
+                true
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "use_1"
+                ],
+                [
+                    "literal",
+                    [
+                        "train",
+                        "vehicle"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Bridge-VT",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(220, 220, 220, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        12,
+                        5
+                    ],
+                    [
+                        15,
+                        5
+                    ],
+                    [
+                        18,
+                        13
+                    ],
+                    [
+                        19,
+                        66
+                    ],
+                    [
+                        22,
+                        400
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "bridge"
+                ],
+                true
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "use_1"
+                ],
+                [
+                    "literal",
+                    [
+                        "train",
+                        "vehicle"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Landuse-Boom",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(73, 73, 73, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        1.5
+                    ],
+                    [
+                        13,
+                        2
+                    ],
+                    [
+                        15,
+                        4
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "boom"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Landuse-Dam",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(211, 211, 211, 1)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        4
+                    ],
+                    [
+                        15,
+                        8.5
+                    ],
+                    [
+                        19,
+                        14.5
+                    ]
+                ]
+            }
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "dam"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "dam_lines"
+    },
+    {
+        "id": "Landuse-MarineFarm-Ln",
+        "type": "line",
+        "paint": {
+            "line-color": "rgba(25, 114, 242, 0.45)",
+            "line-width": 3
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "marine_farm"
+            ]
+        ],
+        "source": "LINZ Basemaps",
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Transport-Tunnel-VT",
+        "type": "line",
+        "paint": {
+            "line-blur": 0,
+            "line-color": "rgba(90, 89, 86, 0.6)",
+            "line-width": {
+                "stops": [
+                    [
+                        10,
+                        0.5
+                    ],
+                    [
+                        15,
+                        1
+                    ],
+                    [
+                        19,
+                        4
+                    ]
+                ]
+            },
+            "line-opacity": 1,
+            "line-dasharray": [
+                4,
+                2.5
+            ],
+            "line-gap-width": 8
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tunnel"
+                ],
+                true
+            ]
+        ],
+        "layout": {
+            "line-cap": "butt",
+            "line-join": "bevel",
+            "visibility": "visible"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Landuse-GravelPit-Label",
+        "type": "symbol",
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "gravel_pit"
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.8,
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        12,
+                        6
+                    ],
+                    [
+                        15,
+                        10
+                    ]
+                ]
+            },
+            "text-field": ""
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "sites"
+    },
+    {
+        "id": "Landuse-MarineFarm-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(232, 232, 232, 1)",
+            "text-halo-color": "rgba(25, 114, 242, 0.45)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "marine_farm"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Roboto Bold Italic"
+            ],
+            "text-field": "{species}"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "Waterway-Rapid-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(239, 239, 239, 0.80)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "stream"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "bottom",
+            "symbol-spacing": 750,
+            "symbol-placement": "line"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "All-Highway-Labels-standard",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(255, 255, 255, 1)",
+            "icon-opacity": {
+                "stops": [
+                    [
+                        6,
+                        0.9
+                    ],
+                    [
+                        14,
+                        1
+                    ]
+                ]
+            },
+            "icon-translate-anchor": "map",
+            "text-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "hway_num"
+            ],
+            [
+                "!",
+                [
+                    "in",
+                    [
+                        "get",
+                        "hway_num"
+                    ],
+                    [
+                        "literal",
+                        [
+                            "6,94",
+                            "2,50",
+                            "1,3",
+                            "12,15",
+                            "14,15",
+                            "6,96",
+                            "25A",
+                            "20A",
+                            "20B",
+                            "29A",
+                            "30A",
+                            "74A",
+                            "67A"
+                        ]
+                    ]
+                ]
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "lane_count"
+                ],
+                1
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        8,
+                        1.2
+                    ],
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        15,
+                        1.7
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        8,
+                        9
+                    ],
+                    [
+                        11,
+                        10
+                    ],
+                    [
+                        15,
+                        14
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:highway_pnt_standard",
+            "text-field": "{hway_num}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "icon-offset": [
+                0,
+                1
+            ],
+            "icon-rotate": 0,
+            "icon-padding": 2,
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-spacing": {
+                "stops": [
+                    [
+                        6,
+                        500
+                    ],
+                    [
+                        13,
+                        400
+                    ]
+                ]
+            },
+            "symbol-placement": "line",
+            "icon-keep-upright": false,
+            "text-keep-upright": true,
+            "icon-pitch-alignment": "viewport",
+            "text-pitch-alignment": "viewport",
+            "icon-text-fit-padding": [
+                1,
+                4,
+                3,
+                3
+            ],
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "All-Highway-Labels-three",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(255, 255, 255, 1)",
+            "icon-opacity": {
+                "stops": [
+                    [
+                        6,
+                        0.9
+                    ],
+                    [
+                        14,
+                        1
+                    ]
+                ]
+            },
+            "icon-translate-anchor": "map",
+            "text-translate-anchor": "map"
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "hway_num"
+                ],
+                [
+                    "literal",
+                    [
+                        "25A",
+                        "20A",
+                        "20B",
+                        "29A",
+                        "30A",
+                        "74A",
+                        "67A"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": {
+                "stops": [
+                    [
+                        8,
+                        1.2
+                    ],
+                    [
+                        12,
+                        1.5
+                    ],
+                    [
+                        15,
+                        1.7
+                    ]
+                ]
+            },
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        8,
+                        9
+                    ],
+                    [
+                        11,
+                        10
+                    ],
+                    [
+                        15,
+                        14
+                    ]
+                ]
+            },
+            "icon-image": "linz-topographic:highway_pnt_wide",
+            "text-field": "{hway_num}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "icon-offset": [
+                0,
+                1
+            ],
+            "icon-rotate": 0,
+            "icon-padding": 2,
+            "text-justify": "center",
+            "icon-text-fit": "none",
+            "symbol-spacing": {
+                "stops": [
+                    [
+                        6,
+                        500
+                    ],
+                    [
+                        13,
+                        400
+                    ]
+                ]
+            },
+            "symbol-placement": "line",
+            "icon-keep-upright": false,
+            "text-keep-upright": true,
+            "icon-pitch-alignment": "viewport",
+            "text-pitch-alignment": "viewport",
+            "icon-text-fit-padding": [
+                1,
+                4,
+                3,
+                3
+            ],
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "viewport"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 8,
+        "source-layer": "streets"
+    },
+    {
+        "id": "All-Road-Labels",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(51, 51, 51, 1)",
+            "text-opacity": 0.9,
+            "text-halo-color": "rgba(243, 243, 242, 0.9)",
+            "text-halo-width": 2.5
+        },
+        "filter": [
+            "all",
+            [
+                "has",
+                "name"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "aerodrome"
+            ],
+            [
+                "!=",
+                [
+                    "get",
+                    "kind"
+                ],
+                "raceway"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        13,
+                        8
+                    ],
+                    [
+                        15,
+                        8
+                    ],
+                    [
+                        18,
+                        10
+                    ],
+                    [
+                        19,
+                        10
+                    ],
+                    [
+                        22,
+                        60
+                    ]
+                ]
+            },
+            "text-field": "{name}",
+            "visibility": "visible",
+            "text-anchor": "center",
+            "text-justify": "center",
+            "icon-text-fit": "both",
+            "symbol-spacing": 250,
+            "text-transform": "none",
+            "symbol-placement": "line",
+            "icon-pitch-alignment": "auto",
+            "icon-ignore-placement": false
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Transport-Tunnel-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(80, 75, 75, 1)",
+            "text-halo-color": "rgba(230, 230, 230, 0.5)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "tunnel"
+                ],
+                true
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Roboto Black"
+            ],
+            "text-size": 10,
+            "text-field": "tunnel",
+            "visibility": "visible",
+            "text-offset": {
+                "stops": [
+                    [
+                        15,
+                        [
+                            0,
+                            -1.25
+                        ]
+                    ],
+                    [
+                        17,
+                        [
+                            0,
+                            -1.75
+                        ]
+                    ],
+                    [
+                        19,
+                        [
+                            0,
+                            -6
+                        ]
+                    ],
+                    [
+                        20,
+                        [
+                            0,
+                            -9
+                        ]
+                    ],
+                    [
+                        22,
+                        [
+                            0,
+                            -16
+                        ]
+                    ]
+                ]
+            },
+            "symbol-spacing": 180,
+            "symbol-placement": "line"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "streets"
+    },
+    {
+        "id": "Airport-Label",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(129, 123, 123, 1)",
+            "icon-opacity": 0.8,
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(255, 255, 255, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "aerodrome"
+            ]
+        ],
+        "layout": {
+            "icon-size": 1.2,
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:airport_airport_pnt_fill",
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "bottom",
+            "icon-offset": [
+                0,
+                0
+            ],
+            "text-anchor": "top",
+            "text-justify": "center",
+            "text-padding": 2,
+            "icon-text-fit": "none",
+            "symbol-spacing": 250,
+            "text-max-width": 5,
+            "text-allow-overlap": false,
+            "icon-pitch-alignment": "viewport",
+            "text-pitch-alignment": "auto",
+            "icon-ignore-placement": false,
+            "icon-rotation-alignment": "viewport",
+            "text-rotation-alignment": "auto"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "public_transport"
+    },
+    {
+        "id": "Aeroway-Airstrip-Label",
+        "type": "symbol",
+        "paint": {
+            "text-halo-blur": 0.5,
+            "text-halo-color": "rgba(246, 246, 246, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "runway"
+            ],
+            [
+                "!",
+                [
+                    "has",
+                    "surface"
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Roboto Light"
+            ],
+            "text-size": 10,
+            "text-field": "airstrip",
+            "visibility": "visible",
+            "text-anchor": "left",
+            "text-justify": "left"
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 15,
+        "source-layer": "street_polygons"
+    },
+    {
+        "id": "All-Reef-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(239, 239, 239, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "reef"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "text-anchor": "center",
+            "text-offset": [
+                0,
+                1
+            ],
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 13,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "All-Lake-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(239, 239, 239, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "water"
+                ],
+                "lake"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "All-River-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(239, 239, 239, 0.80)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "visibility": "visible",
+            "icon-anchor": "center",
+            "text-anchor": "bottom",
+            "text-justify": "center",
+            "symbol-spacing": 1000,
+            "symbol-placement": "line",
+            "icon-allow-overlap": false,
+            "text-allow-overlap": true,
+            "icon-ignore-placement": false,
+            "text-ignore-placement": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_polygons"
+    },
+    {
+        "id": "All-Waterway-River-Names",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-blur": 1,
+            "text-halo-color": "rgba(239, 239, 239, 0.80)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "kind"
+                ],
+                "river"
+            ],
+            [
+                "has",
+                "name"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{name}",
+            "text-anchor": "bottom",
+            "symbol-spacing": 1000,
+            "symbol-placement": "line",
+            "text-allow-overlap": true,
+            "text-ignore-placement": true
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 12,
+        "source-layer": "water_lines"
+    },
+    {
+        "id": "Housenumber",
+        "type": "symbol",
+        "paint": {
+            "icon-color": "rgba(0, 0, 0, 0.6)",
+            "text-color": "rgba(85, 85, 85, 1)",
+            "text-halo-blur": 20,
+            "text-halo-color": "rgba(255, 255, 255, 0.8)",
+            "text-halo-width": 0.5
+        },
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": {
+                "stops": [
+                    [
+                        17,
+                        9
+                    ],
+                    [
+                        19,
+                        10
+                    ]
+                ]
+            },
+            "text-field": "{housenumber}",
+            "text-anchor": "bottom",
+            "text-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 17,
+        "source-layer": "addresses"
+    },
+    {
+        "id": "Place-Label-Lake",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "any",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "lake"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 11,
+        "minzoom": 7,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Bay",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "any",
+            [
+                "in",
+                [
+                    "get",
+                    "natural"
+                ],
+                [
+                    "literal",
+                    [
+                        "bay"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "water"
+                ],
+                [
+                    "literal",
+                    [
+                        "bay",
+                        "lagoon"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Medium"
+            ],
+            "text-size": 10,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 10,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Symbol-Peak-12",
+        "type": "symbol",
+        "paint": {
+            "icon-color": "rgba(61, 162, 86, 1)",
+            "text-color": "rgba(41, 90, 55, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "natural"
+                ],
+                [
+                    "literal",
+                    [
+                        "peak",
+                        "cape",
+                        "peninsula"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.35,
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 10,
+            "icon-image": "linz-topographic:triangle_pnt_fill",
+            "text-field": "",
+            "visibility": "visible",
+            "text-anchor": "left",
+            "text-offset": [
+                0.5,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 12,
+        "minzoom": 10,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Peak-16",
+        "type": "symbol",
+        "paint": {
+            "icon-color": "rgba(61, 162, 86, 1)",
+            "text-color": "rgba(41, 90, 55, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "natural"
+                ],
+                [
+                    "literal",
+                    [
+                        "peak",
+                        "cape",
+                        "peninsula"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.5,
+            "text-font": [
+                "Open Sans Medium"
+            ],
+            "text-size": 11,
+            "icon-image": "linz-topographic:triangle_pnt_fill",
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-anchor": "left",
+            "text-offset": [
+                0.5,
+                0
+            ],
+            "text-justify": "left",
+            "text-optional": true,
+            "text-max-width": 4,
+            "text-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 16,
+        "minzoom": 12,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Suburb",
+        "type": "symbol",
+        "paint": {
+            "text-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(35, 34, 34, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(111, 111, 111, 1)"
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "suburb"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Regular"
+            ],
+            "text-size": 10,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 11,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Locality",
+        "type": "symbol",
+        "paint": {
+            "text-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(35, 34, 34, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(111, 111, 111, 1)"
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "locality"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Medium"
+            ],
+            "text-size": 11,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 9,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Town",
+        "type": "symbol",
+        "paint": {
+            "text-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(35, 34, 34, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(111, 111, 111, 1)"
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1.5
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "town"
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Medium"
+            ],
+            "text-size": 12,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 15,
+        "minzoom": 8,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-City-14",
+        "type": "symbol",
+        "paint": {
+            "text-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(35, 34, 34, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(111, 111, 111, 1)"
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "city"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6,
+                        7,
+                        8
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 15,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "symbol-z-order": "viewport-y",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 14,
+        "minzoom": 7,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Island-12",
+        "type": "symbol",
+        "paint": {
+            "text-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(35, 34, 34, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(111, 111, 111, 1)"
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "island"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        4,
+                        5,
+                        6,
+                        7
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 12,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 12,
+        "minzoom": 8,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Sea-5",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 0.8
+        },
+        "filter": [
+            "any",
+            [
+                "in",
+                [
+                    "get",
+                    "water"
+                ],
+                [
+                    "literal",
+                    [
+                        "sea"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 6,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Sea",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 0.8
+        },
+        "filter": [
+            "any",
+            [
+                "in",
+                [
+                    "get",
+                    "water"
+                ],
+                [
+                    "literal",
+                    [
+                        "seamount",
+                        "searidge",
+                        "seachannel",
+                        "seacanyon"
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 12,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "minzoom": 5,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Lake-7",
+        "type": "symbol",
+        "paint": {
+            "text-color": "rgba(0, 140, 204, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "lake"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        3,
+                        4
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold Italic"
+            ],
+            "text-size": 10,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 7,
+        "minzoom": 6,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-City-7",
+        "type": "symbol",
+        "paint": {
+            "text-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(35, 34, 34, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(111, 111, 111, 1)"
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "==",
+                [
+                    "get",
+                    "place"
+                ],
+                "city"
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 15,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4,
+            "text-allow-overlap": false
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 7,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Island-8",
+        "type": "symbol",
+        "paint": {
+            "text-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(35, 34, 34, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(111, 111, 111, 1)"
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "place"
+                ],
+                [
+                    "literal",
+                    [
+                        "island",
+                        "archipelago"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        3,
+                        4
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 14,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 8,
+        "minzoom": 6,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Island-6",
+        "type": "symbol",
+        "paint": {
+            "text-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(35, 34, 34, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(111, 111, 111, 1)"
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "place"
+                ],
+                [
+                    "literal",
+                    [
+                        "island",
+                        "archipelago"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        2,
+                        3
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 14,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 7
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 6,
+        "minzoom": 5,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Peak-11",
+        "type": "symbol",
+        "paint": {
+            "icon-color": "rgba(61, 162, 86, 1)",
+            "text-color": "rgba(41, 90, 55, 1)",
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 1
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "natural"
+                ],
+                [
+                    "literal",
+                    [
+                        "peak",
+                        "cape",
+                        "peninsula"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        6,
+                        8
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "icon-size": 0.5,
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 11,
+            "icon-image": "linz-topographic:triangle_pnt_fill",
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-anchor": "left",
+            "text-offset": [
+                0.5,
+                0
+            ],
+            "text-justify": "left",
+            "text-max-width": 4,
+            "text-allow-overlap": true
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 14,
+        "source-layer": "place_labels"
+    },
+    {
+        "id": "Place-Label-Island-4",
+        "type": "symbol",
+        "paint": {
+            "text-color": {
+                "stops": [
+                    [
+                        6,
+                        "rgba(35, 34, 34, 1)"
+                    ],
+                    [
+                        19,
+                        "rgba(111, 111, 111, 1)"
+                    ]
+                ]
+            },
+            "text-halo-color": "rgba(255, 252, 252, 1)",
+            "text-halo-width": 2
+        },
+        "filter": [
+            "all",
+            [
+                "in",
+                [
+                    "get",
+                    "place"
+                ],
+                [
+                    "literal",
+                    [
+                        "archipelago"
+                    ]
+                ]
+            ],
+            [
+                "in",
+                [
+                    "get",
+                    "admin_level"
+                ],
+                [
+                    "literal",
+                    [
+                        2
+                    ]
+                ]
+            ]
+        ],
+        "layout": {
+            "text-font": [
+                "Open Sans Bold"
+            ],
+            "text-size": 14,
+            "text-field": "{label}",
+            "visibility": "visible",
+            "text-max-width": 4
+        },
+        "source": "LINZ Basemaps",
+        "maxzoom": 5,
+        "minzoom": 0,
+        "source-layer": "place_labels"
+    }
+]

--- a/api/lib/interface-basemap.ts
+++ b/api/lib/interface-basemap.ts
@@ -83,7 +83,15 @@ export class BasemapProtocol implements BasemapProtocolInterface {
     static isValidStyle(type: string, layers: Array<unknown>): void {
         const sources: Record<string, unknown> = {};
         for (const l of layers as Array<Record<string, string>>) {
-            if (!sources[l.source]) sources[l.source] = { type };
+            if (l.source === undefined) continue; // background layers have no source
+            if (!sources[l.source]) {
+                // hillshade layers require a raster-dem source regardless of the
+                // basemap's own type — register them correctly so validation passes.
+                // '__terrain__' is a sentinel meaning "use whatever raster-dem source
+                // is active at runtime" — always treat it as raster-dem.
+                const isHillshadeOrTerrain = l.type === 'hillshade' || l.source === '__terrain__';
+                sources[l.source] = { type: isHillshadeOrTerrain ? 'raster-dem' : type };
+            }
         }
 
         const errors = validateStyleMin({

--- a/api/lib/types.ts
+++ b/api/lib/types.ts
@@ -120,6 +120,9 @@ export const TileJSON = Type.Object({
     center: Type.Array(Type.Number()),
     type: Type.String(),
     format: Type.Optional(Type.String()),
+    // sprite and glyphs are standard MapLibre style properties — optional since not all basemaps need them
+    sprite: Type.Optional(Type.String()),
+    glyphs: Type.Optional(Type.String()),
     vector_layers: Type.Optional(Type.Array(TileJSON_VectorLayer)),
 });
 

--- a/api/routes/basemap.ts
+++ b/api/routes/basemap.ts
@@ -814,7 +814,12 @@ export default async function router(schema: Schema, config: Config) {
                     throw new Err(400, null, 'Unable to fetch TileJSON from source URL');
                 }
 
-                const json = await tj.json();
+                const json = await tj.json() as any;
+
+                // Strip sprite/glyphs — same reason as the PMTiles branch: external
+                // URLs from upstream TileJSON can't be proxied and will 404.
+                delete json.sprite;
+                delete json.glyphs;
 
                 res.json({
                     ...json,
@@ -836,10 +841,29 @@ export default async function router(schema: Schema, config: Config) {
                 if (!tj.ok) {
                     throw new Err(400, null, 'Unable to fetch TileJSON from hosted basemap');
                 }
-                const tjJson = await tj.json();
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const tjJson = await tj.json() as any;
+
+                // Strip sprite/glyphs from the upstream PMTiles TileJSON — those
+                // reference external URLs that cannot be proxied unless the basemap
+                // record has an explicit tilejson blob overriding them. The blob
+                // spread below will restore them for basemaps that do have a sprite.
+                delete tjJson.sprite;
+                delete tjJson.glyphs;
+
+                // Merge tilejson blob (e.g. sprite) if stored as JSON on the basemap record
+                let tilejsonBlobPmtiles: Record<string, unknown> = {};
+                if (basemap.tilejson && !basemap.tilejson.startsWith('http://') && !basemap.tilejson.startsWith('https://')) {
+                    try {
+                        tilejsonBlobPmtiles = JSON.parse(basemap.tilejson);
+                    } catch {
+                        // Not valid JSON — ignore
+                    }
+                }
 
                 res.json({
                     ...tjJson,
+                    ...tilejsonBlobPmtiles,
                     type: basemap.type,
                     tiles: [tileURL],
                     actions: fromProtocol(basemap.protocol, basemap).actions(),
@@ -852,11 +876,183 @@ export default async function router(schema: Schema, config: Config) {
                     url: tileURL,
                 });
 
+                // If tilejson is a JSON blob (not a URL), merge its fields into the
+                // response — this allows sprite/glyphs and other MapLibre style
+                // properties to be stored per-basemap without a schema change.
+                let tilejsonBlob: Record<string, unknown> = {};
+                if (basemap.tilejson && !basemap.tilejson.startsWith('http://') && !basemap.tilejson.startsWith('https://')) {
+                    try {
+                        tilejsonBlob = JSON.parse(basemap.tilejson);
+                    } catch {
+                        // Not valid JSON — ignore
+                    }
+                }
+
                 res.json({
                     ...json,
+                    ...tilejsonBlob,
                     actions: fromProtocol(basemap.protocol, basemap).actions(),
                 });
             }
+        } catch (err) {
+            Err.respond(err, res);
+        }
+    });
+
+    await schema.get('/basemap/sprite/:name.json', {
+        name: 'Get Named Sprite JSON',
+        group: 'BaseMap',
+        description: 'Proxy a named sprite JSON from LINZ Basemaps. The sprite is served through CloudTAK\'s own domain so the browser CSP is satisfied. Sprite names map directly to LINZ sprite names (e.g. "topographic").',
+        params: Type.Object({
+            name: Type.String(),
+        }),
+        query: Type.Object({
+            token: Type.Optional(Type.String()),
+        }),
+        res: Type.Unknown(),
+    }, async (req, res) => {
+        try {
+            await Auth.is_auth(config, req, { token: true });
+
+            const spriteUrl = `https://basemaps.linz.govt.nz/v1/sprites/${encodeURIComponent(req.params.name)}.json`;
+
+            const upstream = await fetch(spriteUrl);
+            if (!upstream.ok) throw new Err(502, null, `Upstream sprite JSON returned ${upstream.status}`);
+
+            const json = await upstream.json();
+            res.json(json);
+        } catch (err) {
+            Err.respond(err, res);
+        }
+    });
+
+    await schema.get('/basemap/sprite/:name.png', {
+        name: 'Get Named Sprite PNG',
+        group: 'BaseMap',
+        description: 'Proxy a named sprite PNG from LINZ Basemaps. The sprite is served through CloudTAK\'s own domain so the browser CSP is satisfied. Sprite names map directly to LINZ sprite names (e.g. "topographic").',
+        params: Type.Object({
+            name: Type.String(),
+        }),
+        query: Type.Object({
+            token: Type.Optional(Type.String()),
+        }),
+    }, async (req, res) => {
+        try {
+            await Auth.is_auth(config, req, { token: true });
+
+            const spriteUrl = `https://basemaps.linz.govt.nz/v1/sprites/${encodeURIComponent(req.params.name)}.png`;
+
+            const upstream = await fetch(spriteUrl);
+            if (!upstream.ok) throw new Err(502, null, `Upstream sprite PNG returned ${upstream.status}`);
+
+            const buffer = Buffer.from(await upstream.arrayBuffer());
+            res.type('png').send(buffer);
+        } catch (err) {
+            Err.respond(err, res);
+        }
+    });
+
+    await schema.get('/basemap/:basemapid/sprite{:size}.json', {
+        name: 'Get Basemap Sprite JSON',
+        group: 'BaseMap',
+        description: 'Proxy the sprite JSON for a basemap whose tilejson blob contains a sprite URL. Serves the file through CloudTAK\'s own domain so the browser CSP is satisfied without allowing external origins.',
+        params: Type.Object({
+            basemapid: Type.Integer({ minimum: 1 }),
+            size: Type.Optional(Type.String()),
+        }),
+        query: Type.Object({
+            token: Type.Optional(Type.String()),
+        }),
+        res: Type.Unknown(),
+    }, async (req, res) => {
+        try {
+            await Auth.is_auth(config, req, {
+                token: true,
+                resources: [
+                    { access: AuthResourceAccess.BASEMAP, id: req.params.basemapid },
+                ],
+            });
+
+            const basemap = await config.models.Basemap.from(req.params.basemapid);
+
+            if (!basemap.tilejson) throw new Err(404, null, 'This basemap has no sprite configured');
+
+            let tilejsonBlob: Record<string, unknown> = {};
+            try {
+                tilejsonBlob = JSON.parse(basemap.tilejson);
+            } catch {
+                throw new Err(404, null, 'This basemap has no sprite configured');
+            }
+
+            const spriteBase = tilejsonBlob.sprite as string | undefined;
+            if (!spriteBase) throw new Err(404, null, 'This basemap has no sprite configured');
+
+            // req.params.size is either '' or '@2x'
+            const size = req.params.size || '';
+            const spriteUrl = `${spriteBase}${size}.json`;
+
+            if (process.env.StackName !== 'test') {
+                const { safe, reason } = await isSafeUrl(spriteUrl);
+                if (!safe) throw new Err(400, null, `Blocked URL: ${reason}`);
+            }
+
+            const upstream = await fetch(spriteUrl);
+            if (!upstream.ok) throw new Err(502, null, `Upstream sprite JSON returned ${upstream.status}`);
+
+            const json = await upstream.json();
+            res.json(json);
+        } catch (err) {
+            Err.respond(err, res);
+        }
+    });
+
+    await schema.get('/basemap/:basemapid/sprite{:size}.png', {
+        name: 'Get Basemap Sprite PNG',
+        group: 'BaseMap',
+        description: 'Proxy the sprite PNG for a basemap whose tilejson blob contains a sprite URL. Serves the file through CloudTAK\'s own domain so the browser CSP is satisfied without allowing external origins.',
+        params: Type.Object({
+            basemapid: Type.Integer({ minimum: 1 }),
+            size: Type.Optional(Type.String()),
+        }),
+        query: Type.Object({
+            token: Type.Optional(Type.String()),
+        }),
+    }, async (req, res) => {
+        try {
+            await Auth.is_auth(config, req, {
+                token: true,
+                resources: [
+                    { access: AuthResourceAccess.BASEMAP, id: req.params.basemapid },
+                ],
+            });
+
+            const basemap = await config.models.Basemap.from(req.params.basemapid);
+
+            if (!basemap.tilejson) throw new Err(404, null, 'This basemap has no sprite configured');
+
+            let tilejsonBlob: Record<string, unknown> = {};
+            try {
+                tilejsonBlob = JSON.parse(basemap.tilejson);
+            } catch {
+                throw new Err(404, null, 'This basemap has no sprite configured');
+            }
+
+            const spriteBase = tilejsonBlob.sprite as string | undefined;
+            if (!spriteBase) throw new Err(404, null, 'This basemap has no sprite configured');
+
+            const size = req.params.size || '';
+            const spriteUrl = `${spriteBase}${size}.png`;
+
+            if (process.env.StackName !== 'test') {
+                const { safe, reason } = await isSafeUrl(spriteUrl);
+                if (!safe) throw new Err(400, null, `Blocked URL: ${reason}`);
+            }
+
+            const upstream = await fetch(spriteUrl);
+            if (!upstream.ok) throw new Err(502, null, `Upstream sprite PNG returned ${upstream.status}`);
+
+            const buffer = Buffer.from(await upstream.arrayBuffer());
+            res.type('png').send(buffer);
         } catch (err) {
             Err.respond(err, res);
         }

--- a/api/web/src/base/overlay-class.ts
+++ b/api/web/src/base/overlay-class.ts
@@ -15,6 +15,7 @@ import { useMapStore } from '../stores/map.js';
 import ProfileConfig from './profile.ts';
 import Subscription from './subscription.ts';
 import { FeatureVisibility } from '../stores/modules/feature-visibility.ts';
+import OverlayManager from './overlay.ts';
 
 /**
  * @class
@@ -74,9 +75,11 @@ export default class Overlay {
                 for (const layer of ov.styles) {
                     const l = layer as LayerSpecification;
                     l.id = `${ov.id}-${l.id}`;
-                    // @ts-expect-error Special case Background Layer type
-                    l.source = String(ov.id);
-                }
+                    // hillshade layers reference a separate raster-dem source — preserve as-is
+                    if (l.type !== 'hillshade') {
+                        // @ts-expect-error Special case Background Layer type
+                        l.source = String(ov.id);
+                    }                }
             }
 
             ov = await std(`/api/profile/overlay/${ov.id}`, {
@@ -231,6 +234,60 @@ export default class Overlay {
         }
     }
 
+    /**
+     * Ensure a raster-dem source exists on the map for hillshading, returning
+     * its source ID. Does NOT enable 3D terrain — hillshading is a 2D effect
+     * that only needs the raster-dem source to be registered.
+     *
+     * Resolution order:
+     *  1. Any raster-dem source already on the map (e.g. from addTerrain())
+     *  2. Query the API for any raster-dem basemap and add it as source
+     *     '__terrain__' — no setTerrain() call, no 3D mode.
+     *
+     * Returns the source ID, or null if no raster-dem basemap is available.
+     */
+    static async ensureTerrainSource(mapStore: ReturnType<typeof useMapStore>): Promise<string | null> {
+        // 1. Return any raster-dem source already on the map
+        const sources = mapStore.map.getStyle().sources;
+        for (const [id, src] of Object.entries(sources)) {
+            if ((src as { type: string }).type === 'raster-dem') return id;
+        }
+
+        // 2. Load and register the first available raster-dem basemap as a bare
+        //    raster-dem source — hillshading only, no 3D terrain.
+        try {
+            const { value: token } = await Preferences.get({ key: 'token' });
+
+            const listUrl = stdurl('/api/basemap');
+            listUrl.searchParams.set('type', 'raster-dem');
+            listUrl.searchParams.set('hidden', 'all');
+            listUrl.searchParams.set('limit', '1');
+            if (token) listUrl.searchParams.set('token', token);
+
+            const list = await std(listUrl.toString()) as { items: Array<{ id: number; tilesize?: number; encoding?: string }> };
+            if (!list.items.length) return null;
+
+            const terrainId = list.items[0].id;
+            const terrainUrl = stdurl(`/api/basemap/${terrainId}/tiles`);
+            if (token) terrainUrl.searchParams.set('token', token);
+
+            const tileJSON = await std(terrainUrl.toString()) as TileJSON;
+
+            const sourceId = '__terrain__';
+            if (!mapStore.map.getSource(sourceId)) {
+                mapStore.map.addSource(sourceId, {
+                    ...tileJSON,
+                    type: 'raster-dem',
+                });
+            }
+
+            return sourceId;
+        } catch (err) {
+            console.warn('Could not load terrain source for hillshading:', err);
+            return null;
+        }
+    }
+
     async addLayers(before?: string): Promise<void> {
         const mapStore = useMapStore();
 
@@ -242,10 +299,32 @@ export default class Overlay {
         }
 
         for (const l of this.styles) {
+            // @ts-expect-error background layers have no source property
+            let layerSource: string | undefined = l.source;
+
+            // Resolve the __terrain__ sentinel to the actual raster-dem source.
+            // If no terrain source is available yet, skip the layer — it will be
+            // re-attempted when a raster-dem source is added to the map.
+            if (layerSource === '__terrain__') {
+                const terrainId = await Overlay.ensureTerrainSource(mapStore);
+                if (!terrainId) continue;
+                layerSource = terrainId;
+            }
+
+            // Skip layers whose source isn't loaded yet (e.g. a hillshade layer
+            // referencing a raster-dem overlay that hasn't been added to the map).
+            if (layerSource && !mapStore.map.getSource(layerSource)) continue;
+
+            // Clone the layer spec so we can substitute the resolved source
+            // without mutating the stored styles (which must keep '__terrain__').
+            const layerToAdd = layerSource !== (l as LayerSpecification & { source?: string }).source
+                ? { ...l, source: layerSource as string } as LayerSpecification
+                : l;
+
             if (before) {
-                mapStore.map.addLayer(l, before);
+                mapStore.map.addLayer(layerToAdd, before);
             } else {
-                mapStore.map.addLayer(l)
+                mapStore.map.addLayer(layerToAdd);
             }
         }
 
@@ -253,6 +332,17 @@ export default class Overlay {
         // without round-tripping through update()/save() which would PATCH
         // the server with unchanged values.
         for (const l of this.styles) {
+            // @ts-expect-error background layers have no source property
+            let layerSource: string | undefined = l.source;
+            if (layerSource === '__terrain__') {
+                const terrainId = await Overlay.ensureTerrainSource(mapStore);
+                if (!terrainId) continue;
+                layerSource = terrainId;
+            }
+            // Skip layers that were deferred above (source not yet loaded)
+            if (layerSource && !mapStore.map.getSource(layerSource)) continue;
+            if (!mapStore.map.getLayer(l.id)) continue;
+
             if (this.type === 'raster') {
                 mapStore.map.setPaintProperty(l.id, 'raster-opacity', Number(this.opacity));
             }
@@ -447,6 +537,17 @@ export default class Overlay {
             await this.addLayers(opts.before);
         }
         this._loaded = true;
+
+        // If this overlay provides a raster-dem source, other overlays (e.g. a
+        // vector basemap with a hillshade layer) may have deferred layers that
+        // depend on it. Re-attempt adding their deferred layers now.
+        // This covers both explicit raster-dem overlays and the '-2' terrain source.
+        if (this.type === 'raster-dem' || String(this.id) === '-2') {
+            for (const other of OverlayManager.loaded) {
+                if (other === this || !other._loaded) continue;
+                await other.addLayers(opts.before);
+            }
+        }
     }
 
     remove() {
@@ -532,8 +633,13 @@ export default class Overlay {
                 for (const layer of overlay.styles) {
                     const l = layer as LayerSpecification;
                     l.id = `${this.id}-${l.id}`;
-                    // @ts-expect-error Special case Background Layer type
-                    l.source = String(this.id);
+                    // hillshade layers reference a separate raster-dem source
+                    // (a different overlay) — preserve their source as-is.
+                    // All other layer types use this overlay's own source.
+                    if (l.type !== 'hillshade') {
+                        // @ts-expect-error Special case Background Layer type
+                        l.source = String(this.id);
+                    }
                 }
             }
             this.styles = overlay.styles as Array<LayerSpecification>;

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -772,6 +772,18 @@ export const useMapStore = defineStore('cloudtak', {
 
             const sprites = IconManager.defaultSprite();
 
+            // Pre-load the LINZ topographic sprite unconditionally so that any
+            // LINZ vector basemap (Topographic V2, Topolite V2, etc.) can render
+            // fill-pattern, line-pattern and icon-image layers without timing
+            // issues. The sprite is proxied through CloudTAK's own domain to
+            // satisfy the browser CSP. Image references in the LINZ style JSON
+            // files are prefixed with 'linz-topographic:' to match the IDs that
+            // MapLibre assigns to non-default named sprites.
+            sprites.push({
+                id: 'linz-topographic',
+                url: `${String(stdurl('/api/basemap/sprite/topographic'))}${token ? `?token=${encodeURIComponent(token)}` : ''}`
+            });
+
             let initCenter = '-100,40';
             let initZoom = 4;
             let initPitch = 0;

--- a/api/web/src/stores/modules/icons.ts
+++ b/api/web/src/stores/modules/icons.ts
@@ -203,8 +203,14 @@ export default class IconManager {
 
                 this.getColoredIcon(originalIconId, color);
             } else if (e.id.includes(':')) {
-                this.requestedIconsetImageIds.add(e.id);
-                await this.loadIconsetImage(e.id);
+                // Skip LINZ sprite images — these are registered from the
+                // linz-topographic named sprite and handled by MapLibre directly.
+                // Routing them to loadIconsetImage would look for a Dexie iconset
+                // named 'linz-topographic' which doesn't exist.
+                if (!e.id.startsWith('linz-topographic:')) {
+                    this.requestedIconsetImageIds.add(e.id);
+                    await this.loadIconsetImage(e.id);
+                }
             } else if (!this.loggedMissingImageIds.has(e.id)) {
                 this.loggedMissingImageIds.add(e.id);
                 console.info('Unhandled style image missing event', {

--- a/cdk/lib/constructs/cloudtak-api.ts
+++ b/cdk/lib/constructs/cloudtak-api.ts
@@ -272,6 +272,12 @@ export class CloudTakApi extends Construct {
               actions: ['sqs:CreateQueue', 'sqs:DeleteQueue', 'sqs:SetQueueAttributes', 'sqs:ListQueueTags', 'sqs:TagQueue'],
               resources: [`arn:${cdk.Stack.of(this).partition}:sqs:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:TAK-${envConfig.stackName}-CloudTAK-layer-*`]
             }),
+            // ECR permissions — GetAuthorizationToken is global (not repo-scoped)
+            new cdk.aws_iam.PolicyStatement({
+              effect: cdk.aws_iam.Effect.ALLOW,
+              actions: ['ecr:GetAuthorizationToken'],
+              resources: ['*']
+            }),
             // ECR permissions (matching old CloudFormation)
             new cdk.aws_iam.PolicyStatement({
               effect: cdk.aws_iam.Effect.ALLOW,

--- a/scripts/patches/058-fix-isvalidstyle-hillshade-raster-dem.patch
+++ b/scripts/patches/058-fix-isvalidstyle-hillshade-raster-dem.patch
@@ -1,0 +1,273 @@
+diff --git a/api/lib/types.ts b/api/lib/types.ts
+index 98dc02817..77adebcc3 100644
+--- a/api/lib/types.ts
++++ b/api/lib/types.ts
+@@ -120,6 +120,9 @@ export const TileJSON = Type.Object({
+     center: Type.Array(Type.Number()),
+     type: Type.String(),
+     format: Type.Optional(Type.String()),
++    // sprite and glyphs are standard MapLibre style properties — optional since not all basemaps need them
++    sprite: Type.Optional(Type.String()),
++    glyphs: Type.Optional(Type.String()),
+     vector_layers: Type.Optional(Type.Array(TileJSON_VectorLayer)),
+ });
+ 
+diff --git a/api/routes/basemap.ts b/api/routes/basemap.ts
+index dca04ddf5..265290953 100644
+--- a/api/routes/basemap.ts
++++ b/api/routes/basemap.ts
+@@ -838,8 +838,19 @@ export default async function router(schema: Schema, config: Config) {
+                 }
+                 const tjJson = await tj.json();
+ 
++                // Merge tilejson blob (e.g. sprite) if stored as JSON on the basemap record
++                let tilejsonBlobPmtiles: Record<string, unknown> = {};
++                if (basemap.tilejson && !basemap.tilejson.startsWith('http://') && !basemap.tilejson.startsWith('https://')) {
++                    try {
++                        tilejsonBlobPmtiles = JSON.parse(basemap.tilejson);
++                    } catch {
++                        // Not valid JSON — ignore
++                    }
++                }
++
+                 res.json({
+                     ...tjJson,
++                    ...tilejsonBlobPmtiles,
+                     type: basemap.type,
+                     tiles: [tileURL],
+                     actions: fromProtocol(basemap.protocol, basemap).actions(),
+@@ -852,8 +863,21 @@ export default async function router(schema: Schema, config: Config) {
+                     url: tileURL,
+                 });
+ 
++                // If tilejson is a JSON blob (not a URL), merge its fields into the
++                // response — this allows sprite/glyphs and other MapLibre style
++                // properties to be stored per-basemap without a schema change.
++                let tilejsonBlob: Record<string, unknown> = {};
++                if (basemap.tilejson && !basemap.tilejson.startsWith('http://') && !basemap.tilejson.startsWith('https://')) {
++                    try {
++                        tilejsonBlob = JSON.parse(basemap.tilejson);
++                    } catch {
++                        // Not valid JSON — ignore
++                    }
++                }
++
+                 res.json({
+                     ...json,
++                    ...tilejsonBlob,
+                     actions: fromProtocol(basemap.protocol, basemap).actions(),
+                 });
+             }
+diff --git a/api/web/src/base/overlay-class.ts b/api/web/src/base/overlay-class.ts
+index c8d517cbe..1a3224f91 100644
+--- a/api/web/src/base/overlay-class.ts
++++ b/api/web/src/base/overlay-class.ts
+@@ -15,6 +15,7 @@ import { useMapStore } from '../stores/map.js';
+ import ProfileConfig from './profile.ts';
+ import Subscription from './subscription.ts';
+ import { FeatureVisibility } from '../stores/modules/feature-visibility.ts';
++import OverlayManager from './overlay.ts';
+ 
+ /**
+  * @class
+@@ -74,9 +75,11 @@ export default class Overlay {
+                 for (const layer of ov.styles) {
+                     const l = layer as LayerSpecification;
+                     l.id = `${ov.id}-${l.id}`;
+-                    // @ts-expect-error Special case Background Layer type
+-                    l.source = String(ov.id);
+-                }
++                    // hillshade layers reference a separate raster-dem source — preserve as-is
++                    if (l.type !== 'hillshade') {
++                        // @ts-expect-error Special case Background Layer type
++                        l.source = String(ov.id);
++                    }                }
+             }
+ 
+             ov = await std(`/api/profile/overlay/${ov.id}`, {
+@@ -231,6 +234,60 @@ export default class Overlay {
+         }
+     }
+ 
++    /**
++     * Ensure a raster-dem source exists on the map for hillshading, returning
++     * its source ID. Does NOT enable 3D terrain — hillshading is a 2D effect
++     * that only needs the raster-dem source to be registered.
++     *
++     * Resolution order:
++     *  1. Any raster-dem source already on the map (e.g. from addTerrain())
++     *  2. Query the API for any raster-dem basemap and add it as source
++     *     '__terrain__' — no setTerrain() call, no 3D mode.
++     *
++     * Returns the source ID, or null if no raster-dem basemap is available.
++     */
++    static async ensureTerrainSource(mapStore: ReturnType<typeof useMapStore>): Promise<string | null> {
++        // 1. Return any raster-dem source already on the map
++        const sources = mapStore.map.getStyle().sources;
++        for (const [id, src] of Object.entries(sources)) {
++            if ((src as { type: string }).type === 'raster-dem') return id;
++        }
++
++        // 2. Load and register the first available raster-dem basemap as a bare
++        //    raster-dem source — hillshading only, no 3D terrain.
++        try {
++            const { value: token } = await Preferences.get({ key: 'token' });
++
++            const listUrl = stdurl('/api/basemap');
++            listUrl.searchParams.set('type', 'raster-dem');
++            listUrl.searchParams.set('hidden', 'all');
++            listUrl.searchParams.set('limit', '1');
++            if (token) listUrl.searchParams.set('token', token);
++
++            const list = await std(listUrl.toString()) as { items: Array<{ id: number; tilesize?: number; encoding?: string }> };
++            if (!list.items.length) return null;
++
++            const terrainId = list.items[0].id;
++            const terrainUrl = stdurl(`/api/basemap/${terrainId}/tiles`);
++            if (token) terrainUrl.searchParams.set('token', token);
++
++            const tileJSON = await std(terrainUrl.toString()) as TileJSON;
++
++            const sourceId = '__terrain__';
++            if (!mapStore.map.getSource(sourceId)) {
++                mapStore.map.addSource(sourceId, {
++                    ...tileJSON,
++                    type: 'raster-dem',
++                });
++            }
++
++            return sourceId;
++        } catch (err) {
++            console.warn('Could not load terrain source for hillshading:', err);
++            return null;
++        }
++    }
++
+     async addLayers(before?: string): Promise<void> {
+         const mapStore = useMapStore();
+ 
+@@ -242,10 +299,32 @@ export default class Overlay {
+         }
+ 
+         for (const l of this.styles) {
++            // @ts-expect-error background layers have no source property
++            let layerSource: string | undefined = l.source;
++
++            // Resolve the __terrain__ sentinel to the actual raster-dem source.
++            // If no terrain source is available yet, skip the layer — it will be
++            // re-attempted when a raster-dem source is added to the map.
++            if (layerSource === '__terrain__') {
++                const terrainId = await Overlay.ensureTerrainSource(mapStore);
++                if (!terrainId) continue;
++                layerSource = terrainId;
++            }
++
++            // Skip layers whose source isn't loaded yet (e.g. a hillshade layer
++            // referencing a raster-dem overlay that hasn't been added to the map).
++            if (layerSource && !mapStore.map.getSource(layerSource)) continue;
++
++            // Clone the layer spec so we can substitute the resolved source
++            // without mutating the stored styles (which must keep '__terrain__').
++            const layerToAdd = layerSource !== (l as LayerSpecification & { source?: string }).source
++                ? { ...l, source: layerSource as string } as LayerSpecification
++                : l;
++
+             if (before) {
+-                mapStore.map.addLayer(l, before);
++                mapStore.map.addLayer(layerToAdd, before);
+             } else {
+-                mapStore.map.addLayer(l)
++                mapStore.map.addLayer(layerToAdd);
+             }
+         }
+ 
+@@ -253,6 +332,17 @@ export default class Overlay {
+         // without round-tripping through update()/save() which would PATCH
+         // the server with unchanged values.
+         for (const l of this.styles) {
++            // @ts-expect-error background layers have no source property
++            let layerSource: string | undefined = l.source;
++            if (layerSource === '__terrain__') {
++                const terrainId = await Overlay.ensureTerrainSource(mapStore);
++                if (!terrainId) continue;
++                layerSource = terrainId;
++            }
++            // Skip layers that were deferred above (source not yet loaded)
++            if (layerSource && !mapStore.map.getSource(layerSource)) continue;
++            if (!mapStore.map.getLayer(l.id)) continue;
++
+             if (this.type === 'raster') {
+                 mapStore.map.setPaintProperty(l.id, 'raster-opacity', Number(this.opacity));
+             }
+@@ -359,6 +449,37 @@ export default class Overlay {
+             const url = stdurl(this.url);
+             if (token) url.searchParams.set('token', token);
+ 
++            // If the TileJSON includes a sprite URL (stored as a JSON blob in
++            // the basemap's tilejson field), register it as a named sprite
++            // BEFORE adding the source. The sprite must be loaded before tiles
++            // start requesting images, otherwise the first render cycle fires
++            // image lookups before the sprite is available.
++            try {
++                const tileJSON = await std(url.toString()) as TileJSON & { sprite?: string };
++                if (tileJSON.sprite) {
++                    const spriteId = `overlay-${this.id}`;
++                    const existingSprites = mapStore.map.getStyle().sprite;
++                    const alreadyAdded = Array.isArray(existingSprites)
++                        ? existingSprites.some((s: { id: string }) => s.id === spriteId)
++                        : false;
++
++                    if (!alreadyAdded) {
++                        // addSprite is async internally — call it before addSource
++                        // so the sprite starts loading before tiles request images.
++                        // Map.addSprite() doesn't expose a completion callback so
++                        // we can't await it, but starting it here gives it the
++                        // maximum lead time before tile image requests fire.
++                        try {
++                            mapStore.map.addSprite(spriteId, tileJSON.sprite!);
++                        } catch (spriteErr) {
++                            console.warn(`Failed to register sprite ${spriteId}:`, spriteErr);
++                        }
++                    }
++                }
++            } catch (err) {
++                console.warn(`Failed to fetch TileJSON for sprite registration (overlay ${this.id}):`, err);
++            }
++
+             if (!mapStore.map.getSource(String(this.id))) {
+                 // MapLibre resolves the vector TileJSON lazily on first tile
+                 // request, so addSource itself does not throw on a bad URL.
+@@ -447,6 +568,17 @@ export default class Overlay {
+             await this.addLayers(opts.before);
+         }
+         this._loaded = true;
++
++        // If this overlay provides a raster-dem source, other overlays (e.g. a
++        // vector basemap with a hillshade layer) may have deferred layers that
++        // depend on it. Re-attempt adding their deferred layers now.
++        // This covers both explicit raster-dem overlays and the '-2' terrain source.
++        if (this.type === 'raster-dem' || String(this.id) === '-2') {
++            for (const other of OverlayManager.loaded) {
++                if (other === this || !other._loaded) continue;
++                await other.addLayers(opts.before);
++            }
++        }
+     }
+ 
+     remove() {
+@@ -532,8 +664,13 @@ export default class Overlay {
+                 for (const layer of overlay.styles) {
+                     const l = layer as LayerSpecification;
+                     l.id = `${this.id}-${l.id}`;
+-                    // @ts-expect-error Special case Background Layer type
+-                    l.source = String(this.id);
++                    // hillshade layers reference a separate raster-dem source
++                    // (a different overlay) — preserve their source as-is.
++                    // All other layer types use this overlay's own source.
++                    if (l.type !== 'hillshade') {
++                        // @ts-expect-error Special case Background Layer type
++                        l.source = String(this.id);
++                    }
+                 }
+             }
+             this.styles = overlay.styles as Array<LayerSpecification>;

--- a/scripts/patches/059-linz-sprite-proxy.patch
+++ b/scripts/patches/059-linz-sprite-proxy.patch
@@ -1,0 +1,435 @@
+diff --git a/api/routes/basemap.ts b/api/routes/basemap.ts
+index dca04ddf5..dba0b5f6b 100644
+--- a/api/routes/basemap.ts
++++ b/api/routes/basemap.ts
+@@ -814,7 +814,12 @@ export default async function router(schema: Schema, config: Config) {
+                     throw new Err(400, null, 'Unable to fetch TileJSON from source URL');
+                 }
+ 
+-                const json = await tj.json();
++                const json = await tj.json() as any;
++
++                // Strip sprite/glyphs — same reason as the PMTiles branch: external
++                // URLs from upstream TileJSON can't be proxied and will 404.
++                delete json.sprite;
++                delete json.glyphs;
+ 
+                 res.json({
+                     ...json,
+@@ -836,10 +841,29 @@ export default async function router(schema: Schema, config: Config) {
+                 if (!tj.ok) {
+                     throw new Err(400, null, 'Unable to fetch TileJSON from hosted basemap');
+                 }
+-                const tjJson = await tj.json();
++                // eslint-disable-next-line @typescript-eslint/no-explicit-any
++                const tjJson = await tj.json() as any;
++
++                // Strip sprite/glyphs from the upstream PMTiles TileJSON — those
++                // reference external URLs that cannot be proxied unless the basemap
++                // record has an explicit tilejson blob overriding them. The blob
++                // spread below will restore them for basemaps that do have a sprite.
++                delete tjJson.sprite;
++                delete tjJson.glyphs;
++
++                // Merge tilejson blob (e.g. sprite) if stored as JSON on the basemap record
++                let tilejsonBlobPmtiles: Record<string, unknown> = {};
++                if (basemap.tilejson && !basemap.tilejson.startsWith('http://') && !basemap.tilejson.startsWith('https://')) {
++                    try {
++                        tilejsonBlobPmtiles = JSON.parse(basemap.tilejson);
++                    } catch {
++                        // Not valid JSON — ignore
++                    }
++                }
+ 
+                 res.json({
+                     ...tjJson,
++                    ...tilejsonBlobPmtiles,
+                     type: basemap.type,
+                     tiles: [tileURL],
+                     actions: fromProtocol(basemap.protocol, basemap).actions(),
+@@ -852,8 +876,21 @@ export default async function router(schema: Schema, config: Config) {
+                     url: tileURL,
+                 });
+ 
++                // If tilejson is a JSON blob (not a URL), merge its fields into the
++                // response — this allows sprite/glyphs and other MapLibre style
++                // properties to be stored per-basemap without a schema change.
++                let tilejsonBlob: Record<string, unknown> = {};
++                if (basemap.tilejson && !basemap.tilejson.startsWith('http://') && !basemap.tilejson.startsWith('https://')) {
++                    try {
++                        tilejsonBlob = JSON.parse(basemap.tilejson);
++                    } catch {
++                        // Not valid JSON — ignore
++                    }
++                }
++
+                 res.json({
+                     ...json,
++                    ...tilejsonBlob,
+                     actions: fromProtocol(basemap.protocol, basemap).actions(),
+                 });
+             }
+@@ -862,6 +899,165 @@ export default async function router(schema: Schema, config: Config) {
+         }
+     });
+ 
++    await schema.get('/basemap/sprite/:name.json', {
++        name: 'Get Named Sprite JSON',
++        group: 'BaseMap',
++        description: 'Proxy a named sprite JSON from LINZ Basemaps. The sprite is served through CloudTAK\'s own domain so the browser CSP is satisfied. Sprite names map directly to LINZ sprite names (e.g. "topographic").',
++        params: Type.Object({
++            name: Type.String(),
++        }),
++        query: Type.Object({
++            token: Type.Optional(Type.String()),
++        }),
++        res: Type.Unknown(),
++    }, async (req, res) => {
++        try {
++            await Auth.is_auth(config, req, { token: true });
++
++            const spriteUrl = `https://basemaps.linz.govt.nz/v1/sprites/${encodeURIComponent(req.params.name)}.json`;
++
++            const upstream = await fetch(spriteUrl);
++            if (!upstream.ok) throw new Err(502, null, `Upstream sprite JSON returned ${upstream.status}`);
++
++            const json = await upstream.json();
++            res.json(json);
++        } catch (err) {
++            Err.respond(err, res);
++        }
++    });
++
++    await schema.get('/basemap/sprite/:name.png', {
++        name: 'Get Named Sprite PNG',
++        group: 'BaseMap',
++        description: 'Proxy a named sprite PNG from LINZ Basemaps. The sprite is served through CloudTAK\'s own domain so the browser CSP is satisfied. Sprite names map directly to LINZ sprite names (e.g. "topographic").',
++        params: Type.Object({
++            name: Type.String(),
++        }),
++        query: Type.Object({
++            token: Type.Optional(Type.String()),
++        }),
++    }, async (req, res) => {
++        try {
++            await Auth.is_auth(config, req, { token: true });
++
++            const spriteUrl = `https://basemaps.linz.govt.nz/v1/sprites/${encodeURIComponent(req.params.name)}.png`;
++
++            const upstream = await fetch(spriteUrl);
++            if (!upstream.ok) throw new Err(502, null, `Upstream sprite PNG returned ${upstream.status}`);
++
++            const buffer = Buffer.from(await upstream.arrayBuffer());
++            res.type('png').send(buffer);
++        } catch (err) {
++            Err.respond(err, res);
++        }
++    });
++
++    await schema.get('/basemap/:basemapid/sprite{:size}.json', {
++        name: 'Get Basemap Sprite JSON',
++        group: 'BaseMap',
++        description: 'Proxy the sprite JSON for a basemap whose tilejson blob contains a sprite URL. Serves the file through CloudTAK\'s own domain so the browser CSP is satisfied without allowing external origins.',
++        params: Type.Object({
++            basemapid: Type.Integer({ minimum: 1 }),
++            size: Type.Optional(Type.String()),
++        }),
++        query: Type.Object({
++            token: Type.Optional(Type.String()),
++        }),
++        res: Type.Unknown(),
++    }, async (req, res) => {
++        try {
++            await Auth.is_auth(config, req, {
++                token: true,
++                resources: [
++                    { access: AuthResourceAccess.BASEMAP, id: req.params.basemapid },
++                ],
++            });
++
++            const basemap = await config.models.Basemap.from(req.params.basemapid);
++
++            if (!basemap.tilejson) throw new Err(404, null, 'This basemap has no sprite configured');
++
++            let tilejsonBlob: Record<string, unknown> = {};
++            try {
++                tilejsonBlob = JSON.parse(basemap.tilejson);
++            } catch {
++                throw new Err(404, null, 'This basemap has no sprite configured');
++            }
++
++            const spriteBase = tilejsonBlob.sprite as string | undefined;
++            if (!spriteBase) throw new Err(404, null, 'This basemap has no sprite configured');
++
++            // req.params.size is either '' or '@2x'
++            const size = req.params.size || '';
++            const spriteUrl = `${spriteBase}${size}.json`;
++
++            if (process.env.StackName !== 'test') {
++                const { safe, reason } = await isSafeUrl(spriteUrl);
++                if (!safe) throw new Err(400, null, `Blocked URL: ${reason}`);
++            }
++
++            const upstream = await fetch(spriteUrl);
++            if (!upstream.ok) throw new Err(502, null, `Upstream sprite JSON returned ${upstream.status}`);
++
++            const json = await upstream.json();
++            res.json(json);
++        } catch (err) {
++            Err.respond(err, res);
++        }
++    });
++
++    await schema.get('/basemap/:basemapid/sprite{:size}.png', {
++        name: 'Get Basemap Sprite PNG',
++        group: 'BaseMap',
++        description: 'Proxy the sprite PNG for a basemap whose tilejson blob contains a sprite URL. Serves the file through CloudTAK\'s own domain so the browser CSP is satisfied without allowing external origins.',
++        params: Type.Object({
++            basemapid: Type.Integer({ minimum: 1 }),
++            size: Type.Optional(Type.String()),
++        }),
++        query: Type.Object({
++            token: Type.Optional(Type.String()),
++        }),
++    }, async (req, res) => {
++        try {
++            await Auth.is_auth(config, req, {
++                token: true,
++                resources: [
++                    { access: AuthResourceAccess.BASEMAP, id: req.params.basemapid },
++                ],
++            });
++
++            const basemap = await config.models.Basemap.from(req.params.basemapid);
++
++            if (!basemap.tilejson) throw new Err(404, null, 'This basemap has no sprite configured');
++
++            let tilejsonBlob: Record<string, unknown> = {};
++            try {
++                tilejsonBlob = JSON.parse(basemap.tilejson);
++            } catch {
++                throw new Err(404, null, 'This basemap has no sprite configured');
++            }
++
++            const spriteBase = tilejsonBlob.sprite as string | undefined;
++            if (!spriteBase) throw new Err(404, null, 'This basemap has no sprite configured');
++
++            const size = req.params.size || '';
++            const spriteUrl = `${spriteBase}${size}.png`;
++
++            if (process.env.StackName !== 'test') {
++                const { safe, reason } = await isSafeUrl(spriteUrl);
++                if (!safe) throw new Err(400, null, `Blocked URL: ${reason}`);
++            }
++
++            const upstream = await fetch(spriteUrl);
++            if (!upstream.ok) throw new Err(502, null, `Upstream sprite PNG returned ${upstream.status}`);
++
++            const buffer = Buffer.from(await upstream.arrayBuffer());
++            res.type('png').send(buffer);
++        } catch (err) {
++            Err.respond(err, res);
++        }
++    });
++
+     await schema.get('/basemap/:basemapid/tiles/:z/:x/:y', {
+         name: 'Get Basemap Tile',
+         group: 'BaseMap',
+diff --git a/api/web/src/base/overlay-class.ts b/api/web/src/base/overlay-class.ts
+index c8d517cbe..9603c1e5f 100644
+--- a/api/web/src/base/overlay-class.ts
++++ b/api/web/src/base/overlay-class.ts
+@@ -15,6 +15,7 @@ import { useMapStore } from '../stores/map.js';
+ import ProfileConfig from './profile.ts';
+ import Subscription from './subscription.ts';
+ import { FeatureVisibility } from '../stores/modules/feature-visibility.ts';
++import OverlayManager from './overlay.ts';
+ 
+ /**
+  * @class
+@@ -74,9 +75,11 @@ export default class Overlay {
+                 for (const layer of ov.styles) {
+                     const l = layer as LayerSpecification;
+                     l.id = `${ov.id}-${l.id}`;
+-                    // @ts-expect-error Special case Background Layer type
+-                    l.source = String(ov.id);
+-                }
++                    // hillshade layers reference a separate raster-dem source — preserve as-is
++                    if (l.type !== 'hillshade') {
++                        // @ts-expect-error Special case Background Layer type
++                        l.source = String(ov.id);
++                    }                }
+             }
+ 
+             ov = await std(`/api/profile/overlay/${ov.id}`, {
+@@ -231,6 +234,60 @@ export default class Overlay {
+         }
+     }
+ 
++    /**
++     * Ensure a raster-dem source exists on the map for hillshading, returning
++     * its source ID. Does NOT enable 3D terrain — hillshading is a 2D effect
++     * that only needs the raster-dem source to be registered.
++     *
++     * Resolution order:
++     *  1. Any raster-dem source already on the map (e.g. from addTerrain())
++     *  2. Query the API for any raster-dem basemap and add it as source
++     *     '__terrain__' — no setTerrain() call, no 3D mode.
++     *
++     * Returns the source ID, or null if no raster-dem basemap is available.
++     */
++    static async ensureTerrainSource(mapStore: ReturnType<typeof useMapStore>): Promise<string | null> {
++        // 1. Return any raster-dem source already on the map
++        const sources = mapStore.map.getStyle().sources;
++        for (const [id, src] of Object.entries(sources)) {
++            if ((src as { type: string }).type === 'raster-dem') return id;
++        }
++
++        // 2. Load and register the first available raster-dem basemap as a bare
++        //    raster-dem source — hillshading only, no 3D terrain.
++        try {
++            const { value: token } = await Preferences.get({ key: 'token' });
++
++            const listUrl = stdurl('/api/basemap');
++            listUrl.searchParams.set('type', 'raster-dem');
++            listUrl.searchParams.set('hidden', 'all');
++            listUrl.searchParams.set('limit', '1');
++            if (token) listUrl.searchParams.set('token', token);
++
++            const list = await std(listUrl.toString()) as { items: Array<{ id: number; tilesize?: number; encoding?: string }> };
++            if (!list.items.length) return null;
++
++            const terrainId = list.items[0].id;
++            const terrainUrl = stdurl(`/api/basemap/${terrainId}/tiles`);
++            if (token) terrainUrl.searchParams.set('token', token);
++
++            const tileJSON = await std(terrainUrl.toString()) as TileJSON;
++
++            const sourceId = '__terrain__';
++            if (!mapStore.map.getSource(sourceId)) {
++                mapStore.map.addSource(sourceId, {
++                    ...tileJSON,
++                    type: 'raster-dem',
++                });
++            }
++
++            return sourceId;
++        } catch (err) {
++            console.warn('Could not load terrain source for hillshading:', err);
++            return null;
++        }
++    }
++
+     async addLayers(before?: string): Promise<void> {
+         const mapStore = useMapStore();
+ 
+@@ -242,10 +299,32 @@ export default class Overlay {
+         }
+ 
+         for (const l of this.styles) {
++            // @ts-expect-error background layers have no source property
++            let layerSource: string | undefined = l.source;
++
++            // Resolve the __terrain__ sentinel to the actual raster-dem source.
++            // If no terrain source is available yet, skip the layer — it will be
++            // re-attempted when a raster-dem source is added to the map.
++            if (layerSource === '__terrain__') {
++                const terrainId = await Overlay.ensureTerrainSource(mapStore);
++                if (!terrainId) continue;
++                layerSource = terrainId;
++            }
++
++            // Skip layers whose source isn't loaded yet (e.g. a hillshade layer
++            // referencing a raster-dem overlay that hasn't been added to the map).
++            if (layerSource && !mapStore.map.getSource(layerSource)) continue;
++
++            // Clone the layer spec so we can substitute the resolved source
++            // without mutating the stored styles (which must keep '__terrain__').
++            const layerToAdd = layerSource !== (l as LayerSpecification & { source?: string }).source
++                ? { ...l, source: layerSource as string } as LayerSpecification
++                : l;
++
+             if (before) {
+-                mapStore.map.addLayer(l, before);
++                mapStore.map.addLayer(layerToAdd, before);
+             } else {
+-                mapStore.map.addLayer(l)
++                mapStore.map.addLayer(layerToAdd);
+             }
+         }
+ 
+@@ -253,6 +332,17 @@ export default class Overlay {
+         // without round-tripping through update()/save() which would PATCH
+         // the server with unchanged values.
+         for (const l of this.styles) {
++            // @ts-expect-error background layers have no source property
++            let layerSource: string | undefined = l.source;
++            if (layerSource === '__terrain__') {
++                const terrainId = await Overlay.ensureTerrainSource(mapStore);
++                if (!terrainId) continue;
++                layerSource = terrainId;
++            }
++            // Skip layers that were deferred above (source not yet loaded)
++            if (layerSource && !mapStore.map.getSource(layerSource)) continue;
++            if (!mapStore.map.getLayer(l.id)) continue;
++
+             if (this.type === 'raster') {
+                 mapStore.map.setPaintProperty(l.id, 'raster-opacity', Number(this.opacity));
+             }
+@@ -447,6 +537,17 @@ export default class Overlay {
+             await this.addLayers(opts.before);
+         }
+         this._loaded = true;
++
++        // If this overlay provides a raster-dem source, other overlays (e.g. a
++        // vector basemap with a hillshade layer) may have deferred layers that
++        // depend on it. Re-attempt adding their deferred layers now.
++        // This covers both explicit raster-dem overlays and the '-2' terrain source.
++        if (this.type === 'raster-dem' || String(this.id) === '-2') {
++            for (const other of OverlayManager.loaded) {
++                if (other === this || !other._loaded) continue;
++                await other.addLayers(opts.before);
++            }
++        }
+     }
+ 
+     remove() {
+@@ -532,8 +633,13 @@ export default class Overlay {
+                 for (const layer of overlay.styles) {
+                     const l = layer as LayerSpecification;
+                     l.id = `${this.id}-${l.id}`;
+-                    // @ts-expect-error Special case Background Layer type
+-                    l.source = String(this.id);
++                    // hillshade layers reference a separate raster-dem source
++                    // (a different overlay) — preserve their source as-is.
++                    // All other layer types use this overlay's own source.
++                    if (l.type !== 'hillshade') {
++                        // @ts-expect-error Special case Background Layer type
++                        l.source = String(this.id);
++                    }
+                 }
+             }
+             this.styles = overlay.styles as Array<LayerSpecification>;
+diff --git a/api/web/src/stores/map.ts b/api/web/src/stores/map.ts
+index bba4e1681..6f61ff9fc 100644
+--- a/api/web/src/stores/map.ts
++++ b/api/web/src/stores/map.ts
+@@ -772,6 +772,18 @@ export const useMapStore = defineStore('cloudtak', {
+ 
+             const sprites = IconManager.defaultSprite();
+ 
++            // Pre-load the LINZ topographic sprite unconditionally so that any
++            // LINZ vector basemap (Topographic V2, Topolite V2, etc.) can render
++            // fill-pattern, line-pattern and icon-image layers without timing
++            // issues. The sprite is proxied through CloudTAK's own domain to
++            // satisfy the browser CSP. Image references in the LINZ style JSON
++            // files are prefixed with 'linz-topographic:' to match the IDs that
++            // MapLibre assigns to non-default named sprites.
++            sprites.push({
++                id: 'linz-topographic',
++                url: `${String(stdurl('/api/basemap/sprite/topographic'))}${token ? `?token=${encodeURIComponent(token)}` : ''}`
++            });
++
+             let initCenter = '-100,40';
+             let initZoom = 4;
+             let initPitch = 0;

--- a/scripts/patches/PATCH_AUDIT.md
+++ b/scripts/patches/PATCH_AUDIT.md
@@ -45,6 +45,14 @@ The v13.26.0 upstream baseline commit is **418bdc4be**.
 | 050 | *(note)* | Tab visibility reconnect — **superseded by upstream v13** (`reconnect()` and `_boundOnVisibilityChange` already in baseline) | ⬜ Superseded |
 | 051 | `api/lib/authentik-provider.ts`, `api/routes/connection.ts`, `api/routes/login.ts` | Cert renewal uses password auth instead of potentially-revoked cert; removes stale cert-revocation check from login.ts | ✅ Applied & valid |
 | 053 | `api/lib/connection-web.ts`, `api/web/src/base/chatroom-chats.ts`, `api/web/src/components/CloudTAK/Menu/MenuChat.vue`, `api/web/src/components/CloudTAK/Notifications.vue`, `api/web/src/workers/atlas-connection.ts` | Chat/presence fixes: plugin dest routing, chatroom DB ops without fetch(), notification routing, markRead(), scroll-to-bottom, timestamps, Notifications layout | ✅ Applied & valid |
+| 054 | `api/web/src/stores/modules/icons.ts` | Scales down large raster icons to 32px max using canvas; prevents oversized icons from filling the whole screen | ✅ Applied & valid |
+| 055 | `api/web/src/components/CloudTAK/Menu/MenuContacts.vue` | Fixes contacts badge count and adds manual refresh button | ✅ Applied & valid |
+| 056 | `api/web/src/components/CloudTAK/Menu/MenuVideos.vue` | Hides video menu when no media server is configured | ✅ Applied & valid |
+| 057 | `api/routes/ldap.ts` | Falls through to Authentik in all three LDAP routes when CoTAK is not configured | ✅ Applied & valid |
+| 058 | `api/lib/types.ts`, `api/routes/basemap.ts`, `api/web/src/base/overlay-class.ts` | Adds `sprite`/`glyphs` fields to `TileJSON` schema; merges `tilejson` blob into PMTiles and non-URL TileJSON responses; strips upstream `sprite`/`glyphs` to prevent CSP leakage; adds `ensureTerrainSource()` static method and `__terrain__` sentinel resolution for hillshade layers; `OverlayManager` re-attempts deferred hillshade layers when raster-dem source arrives | ✅ Applied & valid |
+| 059 | `api/routes/basemap.ts`, `api/web/src/base/overlay-class.ts`, `api/web/src/stores/map.ts` | LINZ sprite proxy: adds `GET /api/basemap/sprite/:name.json` and `.png` routes (auth-only, proxies to LINZ public CDN); pre-loads `linz-topographic` sprite unconditionally in map init style (before any overlays load); removes per-overlay reactive sprite registration code that caused timing races | ✅ Applied & valid |
+
+> **Note:** The LINZ vector style JSON files (`LINZ_Vector_Map_Styles/LINZ_Topographic_V2_Hillshade.migrated.json` and `LINZ_Topolite_V2_Hillshade.migrated.json`) have all `fill-pattern`, `line-pattern`, and `icon-image` values prefixed with `linz-topographic:` to match the sprite ID MapLibre assigns to non-default named sprites. These files are untracked by git and must be updated manually when re-deploying to a fresh environment.
 
 ---
 


### PR DESCRIPTION
Enables full rendering of LINZ vector basemaps (Topographic V2 and Topolite V2) including hillshade layers and all sprite-based imagery (fill patterns, line patterns, point icons).

**Problem**

LINZ vector basemaps use a MapLibre sprite for ~70 image references (`fill-pattern`, `line-pattern`, `icon-image`). Two issues prevented these from rendering:

1. `isValidStyle()` rejected hillshade layers that reference a `raster-dem` source, blocking the styles from being saved
2. MapLibre prefixes images from named sprites as `<spriteId>:<imageName>` — the style JSON had bare names that never matched, causing every image to fire `styleimagemissing` indefinitely

**Changes**

*Server — hillshade support:*
- `interface-basemap.ts`: `isValidStyle()` now accepts hillshade layers with raster-dem sources and the `__terrain__` sentinel
- `types.ts`: adds optional `sprite`/`glyphs` fields to `TileJSON` schema
- `basemap.ts`: merges `tilejson` blob into PMTiles and non-URL TileJSON responses; strips upstream `sprite`/`glyphs` to prevent external URLs leaking to the browser (CSP)

*Server — sprite proxy:*
- `basemap.ts`: adds `GET /api/basemap/sprite/:name.json` and `.png` — authenticated pass-through to the LINZ public CDN, no DB lookup needed

*Frontend:*
- `map.ts`: unconditionally pre-loads the `linz-topographic` sprite at map init time via the proxy, before any overlays load
- `overlay-class.ts`: adds `ensureTerrainSource()` for hillshade layers; resolves `__terrain__` sentinel at render time; removes the previous reactive per-overlay sprite registration code that caused timing races

*Style JSON:*
- `LINZ_Topographic_V2_Hillshade.migrated.json` and `LINZ_Topolite_V2_Hillshade.migrated.json`: all `fill-pattern`, `line-pattern`, and `icon-image` values prefixed with `linz-topographic:` to match MapLibre's named-sprite image ID format

**Testing**

Deployed and verified on the TAK.NZ demo environment. LINZ Topographic V2 vector map renders correctly with vegetation textures, cliff/embankment line patterns, and all point icons.