### PR TITLE
Improve performance

### DIFF
--- a/api/routes/icons.ts
+++ b/api/routes/icons.ts
@@ -425,11 +425,27 @@ export default async function router(schema: Schema, config: Config) {
             if (req.query.scope === ResourceCreationScope.SERVER) scope = sql`username IS NULL`;
             else if (req.query.scope === ResourceCreationScope.USER) scope = sql`username IS NOT NULL`;
 
+            let iconset;
             if (req.query.iconset) {
-                const iconset = await config.models.Iconset.from(req.query.iconset);
+                iconset = await config.models.Iconset.from(req.query.iconset);
                 if (iconset.username && iconset.username !== user.email && user.access === AuthUserAccess.USER) {
                     throw new Err(400, null, 'You don\'t have permission to access this resource');
                 }
+
+                // When scoped to a single iconset, the response is stable for a given
+                // version+updated pair, so we can return a strong ETag and allow shared
+                // caching. A 304 short-circuits the entire DB icon fetch for repeat loads.
+                const etag = `"${iconset.uid}-v${iconset.version}-${new Date(iconset.updated).getTime()}"`;
+                res.set('ETag', etag);
+                res.set('Cache-Control', 'public, max-age=3600, stale-while-revalidate=86400');
+
+                if (req.headers['if-none-match'] === etag) {
+                    res.status(304).end();
+                    return;
+                }
+            } else {
+                // Without an iconset filter the result set is dynamic — don't cache.
+                res.set('Cache-Control', 'no-store');
             }
 
             const list = await config.models.Icon.list({

--- a/cdk/lib/cloudtak-stack.ts
+++ b/cdk/lib/cloudtak-stack.ts
@@ -363,9 +363,6 @@ export class CloudTakStack extends cdk.Stack {
       kmsKey,
       hostedZone,
       certificate,
-      vpc,
-      efsAccessPoint: pmtilesEfs.accessPoint,
-      lambdaSecurityGroup: pmtilesEfs.lambdaSecurityGroup
     });
 
     // Create ECS Fargate service for the CloudTAK API

--- a/cdk/lib/constructs/database.ts
+++ b/cdk/lib/constructs/database.ts
@@ -154,7 +154,7 @@ export class Database extends Construct {
         defaultDatabaseName: DATABASE_CONSTANTS.DEFAULT_DATABASE_NAME,
         port: DATABASE_CONSTANTS.PORT,
         networkType: rds.NetworkType.DUAL,
-        serverlessV2MinCapacity: 0.5,
+        serverlessV2MinCapacity: 2,
         serverlessV2MaxCapacity: 4,
         writer: rds.ClusterInstance.serverlessV2('writer'),
         readers: dbConfig.instanceCount > 1 ? 

--- a/cdk/lib/constructs/lambda-functions.ts
+++ b/cdk/lib/constructs/lambda-functions.ts
@@ -19,8 +19,6 @@ import * as ecrAssets from 'aws-cdk-lib/aws-ecr-assets';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
 import * as route53 from 'aws-cdk-lib/aws-route53';
-import * as efs from 'aws-cdk-lib/aws-efs';
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { ContextEnvironmentConfig } from '../stack-config';
 
 export interface LambdaFunctionsProps {
@@ -33,9 +31,6 @@ export interface LambdaFunctionsProps {
   kmsKey: cdk.aws_kms.IKey;
   hostedZone: cdk.aws_route53.IHostedZone;
   certificate: cdk.aws_certificatemanager.ICertificate;
-  vpc: ec2.IVpc;
-  efsAccessPoint: efs.IAccessPoint;
-  lambdaSecurityGroup: ec2.ISecurityGroup;
 }
 
 export class LambdaFunctions extends Construct {
@@ -55,9 +50,6 @@ export class LambdaFunctions extends Construct {
       kmsKey,
       hostedZone,
       certificate,
-      vpc,
-      efsAccessPoint,
-      lambdaSecurityGroup,
     } = props;
 
     const cloudtakImageTag =
@@ -88,24 +80,12 @@ export class LambdaFunctions extends Construct {
                 `arn:${cdk.Stack.of(this).partition}:secretsmanager:${cdk.Stack.of(this).region}:${cdk.Stack.of(this).account}:secret:TAK-${envConfig.stackName}-*`,
               ],
             }),
-            new iam.PolicyStatement({
-              effect: iam.Effect.ALLOW,
-              actions: [
-                'elasticfilesystem:ClientMount',
-                'elasticfilesystem:ClientWrite',
-                'elasticfilesystem:DescribeMountTargets',
-              ],
-              resources: ['*'],
-            }),
           ],
         }),
       },
       managedPolicies: [
         iam.ManagedPolicy.fromAwsManagedPolicyName(
           'service-role/AWSLambdaBasicExecutionRole',
-        ),
-        iam.ManagedPolicy.fromAwsManagedPolicyName(
-          'service-role/AWSLambdaVPCAccessExecutionRole',
         ),
       ],
     });
@@ -134,7 +114,7 @@ export class LambdaFunctions extends Construct {
           }),
       handler: lambda.Handler.FROM_IMAGE,
       role: tilesLambdaRole,
-      memorySize: 256,
+      memorySize: 512,
       timeout: cdk.Duration.seconds(60),
       description: 'Return Mapbox Vector Tiles from a PMTiles Store',
       environment: {
@@ -147,13 +127,15 @@ export class LambdaFunctions extends Construct {
         SigningSecret: `{{resolve:secretsmanager:${signingSecret.secretName}:SecretString::AWSCURRENT}}`,
       },
       environmentEncryption: kmsKey,
-      vpc,
-      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
-      securityGroups: [lambdaSecurityGroup],
-      filesystem: lambda.FileSystem.fromEfsAccessPoint(
-        efsAccessPoint,
-        '/mnt/efs',
-      ),
+    });
+
+    // Provisioned concurrency — keeps 10 containers warm to eliminate cold starts
+    // on concurrent tile bursts when a user first loads the map.
+    const version = this.tilesLambda.currentVersion;
+    new lambda.Alias(this, 'PMTilesLambdaLive', {
+      aliasName: 'live',
+      version,
+      provisionedConcurrentExecutions: 10,
     });
 
     // -------------------------------------------------------------------------

--- a/cdk/test/unit/constructs/lambda-functions.test.ts
+++ b/cdk/test/unit/constructs/lambda-functions.test.ts
@@ -1,8 +1,7 @@
+
 import { App, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import * as efs from 'aws-cdk-lib/aws-efs';
 import { LambdaFunctions } from '../../../lib/constructs/lambda-functions';
 import { CDKTestHelper } from '../../__helpers__/cdk-test-utils';
 import { MOCK_CONFIGS } from '../../__fixtures__/mock-configs';
@@ -21,22 +20,6 @@ describe('LambdaFunctions Construct', () => {
       'arn:aws:acm:us-west-2:123456789012:certificate/test-cert'
     );
     const { signingSecret } = CDKTestHelper.createMockSecrets(stack);
-    
-    // Mock VPC, EFS, and Security Group
-    const vpc = ec2.Vpc.fromVpcAttributes(stack, 'TestVpc1', {
-      vpcId: 'vpc-12345',
-      availabilityZones: ['us-east-1a', 'us-east-1b'],
-      privateSubnetIds: ['subnet-1', 'subnet-2']
-    });
-    const fileSystem = efs.FileSystem.fromFileSystemAttributes(stack, 'TestEfs1', {
-      fileSystemId: 'fs-12345',
-      securityGroup: ec2.SecurityGroup.fromSecurityGroupId(stack, 'TestEfsSg1', 'sg-efs-12345')
-    });
-    const efsAccessPoint = efs.AccessPoint.fromAccessPointAttributes(stack, 'TestEfsAp1', {
-      accessPointId: 'fsap-12345',
-      fileSystem
-    });
-    const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(stack, 'TestSg1', 'sg-12345');
 
     const lambdaFunctions = new LambdaFunctions(stack, 'TestLambdaFunctions', {
       envConfig: MOCK_CONFIGS.DEV_TEST,
@@ -47,9 +30,6 @@ describe('LambdaFunctions Construct', () => {
       serviceUrl: 'https://test.example.com',
       assetBucketName: 'test-bucket',
       signingSecret,
-      vpc,
-      efsAccessPoint,
-      lambdaSecurityGroup
     });
 
     expect(lambdaFunctions.tilesLambda).toBeDefined();
@@ -74,22 +54,6 @@ describe('LambdaFunctions Construct', () => {
       'arn:aws:acm:us-west-2:123456789012:certificate/test-cert'
     );
     const { signingSecret } = CDKTestHelper.createMockSecrets(stack);
-    
-    // Mock VPC, EFS, and Security Group
-    const vpc = ec2.Vpc.fromVpcAttributes(stack, 'TestVpc2', {
-      vpcId: 'vpc-12345',
-      availabilityZones: ['us-east-1a', 'us-east-1b'],
-      privateSubnetIds: ['subnet-1', 'subnet-2']
-    });
-    const fileSystem = efs.FileSystem.fromFileSystemAttributes(stack, 'TestEfs2', {
-      fileSystemId: 'fs-12345',
-      securityGroup: ec2.SecurityGroup.fromSecurityGroupId(stack, 'TestEfsSg2', 'sg-efs-12345')
-    });
-    const efsAccessPoint = efs.AccessPoint.fromAccessPointAttributes(stack, 'TestEfsAp2', {
-      accessPointId: 'fsap-12345',
-      fileSystem
-    });
-    const lambdaSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(stack, 'TestSg2', 'sg-12345');
 
     new LambdaFunctions(stack, 'TestLambdaFunctions', {
       envConfig: MOCK_CONFIGS.DEV_TEST,
@@ -100,9 +64,6 @@ describe('LambdaFunctions Construct', () => {
       serviceUrl: 'https://test.example.com',
       assetBucketName: 'test-bucket',
       signingSecret,
-      vpc,
-      efsAccessPoint,
-      lambdaSecurityGroup
     });
 
     const template = Template.fromStack(stack);


### PR DESCRIPTION
Improve performance: Aurora min ACU, Lambda memory/VPC/concurrency, icon ETag caching - Raise Aurora Serverless v2 min capacity from 0.5 to 2 ACU (CloudTAK DB) - PMTiles Lambda: memory 256 -> 512 MB - PMTiles Lambda: remove VPC attachment and EFS mount (EFS was unused for tile serving) - PMTiles Lambda: add provisioned concurrency of 10 to eliminate cold starts - GET /api/icon: add ETag + Cache-Control when filtered by a single iconset, allowing the browser to 304 on repeat loads instead of re-fetching up to 10 MB of base64 icon data on every cold cache