### PR TITLE
fix: config cache stale null + bottom bar coordinates styling

### DIFF
--- a/api/web/src/base/config.ts
+++ b/api/web/src/base/config.ts
@@ -80,11 +80,18 @@ export default class Config<K extends keyof FullConfig = keyof FullConfig> {
                 if (result[key] === undefined && opts.defaults[key] !== undefined) {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     result[key] = opts.defaults[key] as any;
-                    defaultsToSave.push({
-                        key: String(key),
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        value: opts.defaults[key] as any
-                    });
+
+                    // Only cache non-null defaults. A null default means "not configured",
+                    // which is a sentinel value that should not be persisted — doing so would
+                    // prevent the app from picking up a real value after an admin later sets
+                    // the config key (until the user hard-reloads to clear IndexedDB).
+                    if (opts.defaults[key] != null) {
+                        defaultsToSave.push({
+                            key: String(key),
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            value: opts.defaults[key] as any
+                        });
+                    }
                 }
             }
 

--- a/api/web/src/components/CloudTAK/BottomBar/BottomBarCoordinates.vue
+++ b/api/web/src/components/CloudTAK/BottomBar/BottomBarCoordinates.vue
@@ -14,13 +14,13 @@
                     :class='isNative ? "" : "cursor-pointer cloudtak-hover pe-5"'
                 >
                     <span
-                        class='d-block text-uppercase text-white-50'
-                        style='font-size: 0.65rem; line-height: 1.1; letter-spacing: 0.04em;'
-                    >{{ coordSource === 'gps' ? 'GPS Location' : 'Cursor Position' }}</span>
-                    <span
-                        class='d-block text-truncate'
-                        style='font-size: 0.85rem; line-height: 1.2; font-variant-numeric: tabular-nums;'
+                        class='d-block fw-semibold'
+                        style='line-height: 1.2; font-variant-numeric: tabular-nums;'
                     >{{ formattedCoord }}</span>
+                    <span
+                        class='d-block text-white-50'
+                        style='font-size: 0.7rem; line-height: 1.2;'
+                    >{{ coordSource === 'gps' ? 'GPS location' : 'Cursor position' }}</span>
                 </div>
             </template>
 

--- a/scripts/patches/062-fix-null-config-default-caching.patch
+++ b/scripts/patches/062-fix-null-config-default-caching.patch
@@ -1,0 +1,28 @@
+diff --git a/api/web/src/base/config.ts b/api/web/src/base/config.ts
+index fc0ee7886..7bea063b8 100644
+--- a/api/web/src/base/config.ts
++++ b/api/web/src/base/config.ts
+@@ -80,11 +80,18 @@ export default class Config<K extends keyof FullConfig = keyof FullConfig> {
+                 if (result[key] === undefined && opts.defaults[key] !== undefined) {
+                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                     result[key] = opts.defaults[key] as any;
+-                    defaultsToSave.push({
+-                        key: String(key),
+-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+-                        value: opts.defaults[key] as any
+-                    });
++
++                    // Only cache non-null defaults. A null default means "not configured",
++                    // which is a sentinel value that should not be persisted — doing so would
++                    // prevent the app from picking up a real value after an admin later sets
++                    // the config key (until the user hard-reloads to clear IndexedDB).
++                    if (opts.defaults[key] != null) {
++                        defaultsToSave.push({
++                            key: String(key),
++                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
++                            value: opts.defaults[key] as any
++                        });
++                    }
+                 }
+             }
+ 

--- a/scripts/patches/063-bottom-bar-coordinates-style-consistency.patch
+++ b/scripts/patches/063-bottom-bar-coordinates-style-consistency.patch
@@ -1,0 +1,24 @@
+diff --git a/api/web/src/components/CloudTAK/BottomBar/BottomBarCoordinates.vue b/api/web/src/components/CloudTAK/BottomBar/BottomBarCoordinates.vue
+index 3bbdcb354..5109674e4 100644
+--- a/api/web/src/components/CloudTAK/BottomBar/BottomBarCoordinates.vue
++++ b/api/web/src/components/CloudTAK/BottomBar/BottomBarCoordinates.vue
+@@ -14,13 +14,13 @@
+                     :class='isNative ? "" : "cursor-pointer cloudtak-hover pe-5"'
+                 >
+                     <span
+-                        class='d-block text-uppercase text-white-50'
+-                        style='font-size: 0.65rem; line-height: 1.1; letter-spacing: 0.04em;'
+-                    >{{ coordSource === 'gps' ? 'GPS Location' : 'Cursor Position' }}</span>
+-                    <span
+-                        class='d-block text-truncate'
+-                        style='font-size: 0.85rem; line-height: 1.2; font-variant-numeric: tabular-nums;'
++                        class='d-block fw-semibold'
++                        style='line-height: 1.2; font-variant-numeric: tabular-nums;'
+                     >{{ formattedCoord }}</span>
++                    <span
++                        class='d-block text-white-50'
++                        style='font-size: 0.7rem; line-height: 1.2;'
++                    >{{ coordSource === 'gps' ? 'GPS location' : 'Cursor position' }}</span>
+                 </div>
+             </template>
+ 


### PR DESCRIPTION
## Changes

**Fix: null config defaults cached in IndexedDB (`config.ts`)**

`Config.list()` was persisting `null` defaults (e.g. `'map::terrain': null`) into IndexedDB. Once cached, the null value shadowed the real server config on all subsequent loads, meaning features that depend on admin-configured keys — like the 3D terrain toggle — would never appear after being set, until the user did a hard reload to clear site data.

The fix is a one-line guard: only write defaults to IndexedDB if they are non-null. A `null` default is a sentinel for "not yet configured" and should never block a future live fetch.

**Fix: `BottomBarCoordinates` style inconsistency**

The cursor/GPS coordinates widget in the bottom bar had a different visual hierarchy to the adjacent callsign widget — uppercase small label on top, larger value below, with different font sizes and letter-spacing.

Aligned it with `BottomBarCallsign`: value on top (`fw-semibold`), label underneath (`text-white-50`, `0.7rem`). Also corrected label capitalisation to sentence case: "Cursor position" / "GPS location".

## Testing

- Configure a `map::terrain` basemap in Admin → Config → Map, then load the app fresh (without a hard reload) — the 3D mountain icon should now appear in the map controls without requiring a cache clear.
- Bottom bar coordinates widget visually matches the callsign widget layout.