### PR TITLE
fix: restore S3 config file during demo prod deploy

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Deploy Demo with Prod Profile
         run: |
           cd cdk
-          npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.DEMO_STACK_NAME }} --context usePreBuiltImages=true --context cloudtakImageTag=${{ steps.images.outputs.cloudtak-tag }} --context useS3CloudTAKConfigFile=false ${{ steps.db-config.outputs.db-context }} --require-approval never
+          npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.DEMO_STACK_NAME }} --context usePreBuiltImages=true --context cloudtakImageTag=${{ steps.images.outputs.cloudtak-tag }} ${{ steps.db-config.outputs.db-context }} --require-approval never
 
       - name: Wait for Testing Period
         run: sleep ${{ vars.DEMO_TEST_DURATION || '300' }}


### PR DESCRIPTION
## Problem

When the demo pipeline deployed with the prod profile, the LINZ basemap tiles stopped working. The browser's CSP blocked requests to `https://basemaps.linz.govt.nz` because it was absent from `connect-src` and `img-src`.

The CSP is built at container startup by `nginx.conf.js`, which reads `CLOUDTAK_TILE_ORIGINS` to populate those directives. That variable lives in the S3 `cloudtak-config.env` file — but the prod deploy step was passing `--context useS3CloudTAKConfigFile=false`, which prevented the S3 env file from being mounted on the container. With no `CLOUDTAK_TILE_ORIGINS` set, the tile origins array was empty and the LINZ CDN was never added to the CSP.

The revert-to-dev-test step was unaffected because it correctly passed `--context useS3CloudTAKConfigFile=true`.

## Fix

Remove `--context useS3CloudTAKConfigFile=false` from the prod deploy step. The prod profile's `cdk.json` default is already `useS3CloudTAKConfigFile: true`, so no replacement flag is needed — the S3 env file is now loaded during the prod deploy, and `CLOUDTAK_TILE_ORIGINS` reaches the container as expected.

## Testing

- Deploy demo pipeline with prod profile → LINZ basemap tiles should load correctly
- CSP `connect-src` and `img-src` should include `https://basemaps.linz.govt.nz`