### PR TITLE
fix: symbol icons take click priority over line and fill layers

### DIFF
--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -1023,17 +1023,30 @@ export const useMapStore = defineStore('cloudtak', {
 
                 // Each Visual Layer will return a Feature for a click
                 // Since a single "feature" may exist in multiple layers (text, polygon, line) etc
-                // dedupe them based on the ID
+                // dedupe them based on the ID. Sort by layer type first so that symbol (point/icon)
+                // layers take precedence over fill/line layers in the dedupe — this ensures a point
+                // icon's symbol representation wins over its own fill/line when a feature has both.
+                const LAYER_CLICK_PRIORITY: Record<string, number> = { symbol: 0, line: 1, fill: 2 };
                 const dedupe: Map<string, MapGeoJSONFeature> = new Map();
                 map.queryRenderedFeatures(e.point)
                     .filter((feat) => {
                         return clickMap.has(feat.layer.id);
                     })
+                    .sort((a, b) => {
+                        return (LAYER_CLICK_PRIORITY[a.layer.type] ?? 3) - (LAYER_CLICK_PRIORITY[b.layer.type] ?? 3);
+                    })
                     .forEach((feat) => {
                         dedupe.set(String(feat.properties.id || feat.id), feat);
                     })
 
-                const features = Array.from(dedupe.values());
+                // If any symbol (point/icon) feature is present, suppress line and fill features
+                // from the result set. This prevents street lines or polygon fills from other
+                // overlays blocking selection of a point icon at the same map location.
+                let features = Array.from(dedupe.values());
+                const hasSymbol = features.some((f) => f.layer.type === 'symbol');
+                if (hasSymbol) {
+                    features = features.filter((f) => f.layer.type === 'symbol');
+                }
 
                 if (!features.length) return;
 

--- a/bug-reports/kmz-icons-unselectable-under-cot-polygons.md
+++ b/bug-reports/kmz-icons-unselectable-under-cot-polygons.md
@@ -1,0 +1,38 @@
+# Bug: KMZ/KML icons are unselectable when obscured by a CoT polygon
+
+## Description
+
+KMZ/KML imports are rendered as overlays, which sit below the CoT feature layer in the MapLibre layer stack. When a CoT polygon (e.g. a drawn area, geofence, or shape shared via ATAK) covers the same map area as a KMZ/KML point icon, the CoT polygon's fill intercepts all click/tap events at that location. The KMZ icon underneath becomes completely unselectable — the user cannot open its popup or description panel regardless of how precisely they click on it.
+
+## Steps to Reproduce
+
+1. Import a KMZ/KML file that contains point icons with descriptions (e.g. camera markers, POI markers).
+2. Ensure a CoT polygon exists on the map that spatially overlaps one or more of those icons — this can be a drawn shape, a shared ATAK polygon, or a mission geometry.
+3. Attempt to click/tap the KMZ icon underneath the polygon.
+
+**Expected:** Clicking the icon opens its description/popup, regardless of what CoT features are layered on top.  
+**Actual:** The click is consumed by the CoT polygon fill. The KMZ icon's click handler never fires.
+
+## Root Cause
+
+MapLibre resolves click targets by hit-testing layers in reverse paint order — the topmost rendered layer wins. CoT features (polygons, lines, points) are added to the map after overlay layers, placing them higher in the stack. A CoT polygon's fill layer has a non-zero interactive hit area covering its entire extent, so any click within that area is attributed to the polygon rather than to any overlay icon underneath it.
+
+This is not a MapLibre limitation per se — MapLibre's `queryRenderedFeatures` can return features from multiple layers at a given point. The issue is that CloudTAK's click handler stops at the first match rather than checking all features at the click location across all layers.
+
+## Impact
+
+- Any KMZ/KML point icon that falls within the bounds of a CoT polygon becomes inaccessible to the user.
+- This is particularly problematic for operational use cases where KMZ overlays (e.g. infrastructure markers, camera feeds, sensor locations) are combined with area-of-operations polygons drawn by TAK users.
+- The user has no visual indication that a selectable feature exists under the polygon — there is no z-order affordance in the UI.
+
+## Recommended Fix
+
+In the map click handler, use `map.queryRenderedFeatures(point, { layers: [...all interactive layers...] })` to collect **all** features at the click location across all layers rather than relying on the first match from the event target. Then apply a priority order:
+
+1. Point/icon features (CoT or overlay) — highest priority since they are smallest hit targets.
+2. Line features.
+3. Polygon features — lowest priority since they cover the largest area.
+
+Within each tier, prefer the topmost layer. This ensures a KMZ icon obscured by a polygon fill is still selectable, matching the behaviour of ATAK and Google Earth where point features always take click precedence over area features regardless of render order.
+
+A simpler short-term mitigation is to set `fill-opacity: 0` (or very low) on CoT polygon layers while keeping `fill-outline-color` visible, so the polygon's hit area is reduced to its outline only. However this changes the visual appearance and is not a correct fix.

--- a/scripts/patches/064-fix-click-priority-symbol-over-fill.patch
+++ b/scripts/patches/064-fix-click-priority-symbol-over-fill.patch
@@ -1,0 +1,37 @@
+diff --git a/api/web/src/stores/map.ts b/api/web/src/stores/map.ts
+index 48d410777..c7217f7a7 100644
+--- a/api/web/src/stores/map.ts
++++ b/api/web/src/stores/map.ts
+@@ -1023,17 +1023,30 @@ export const useMapStore = defineStore('cloudtak', {
+ 
+                 // Each Visual Layer will return a Feature for a click
+                 // Since a single "feature" may exist in multiple layers (text, polygon, line) etc
+-                // dedupe them based on the ID
++                // dedupe them based on the ID. Sort by layer type first so that symbol (point/icon)
++                // layers take precedence over fill/line layers in the dedupe — this ensures a point
++                // icon's symbol representation wins over its own fill/line when a feature has both.
++                const LAYER_CLICK_PRIORITY: Record<string, number> = { symbol: 0, line: 1, fill: 2 };
+                 const dedupe: Map<string, MapGeoJSONFeature> = new Map();
+                 map.queryRenderedFeatures(e.point)
+                     .filter((feat) => {
+                         return clickMap.has(feat.layer.id);
+                     })
++                    .sort((a, b) => {
++                        return (LAYER_CLICK_PRIORITY[a.layer.type] ?? 3) - (LAYER_CLICK_PRIORITY[b.layer.type] ?? 3);
++                    })
+                     .forEach((feat) => {
+                         dedupe.set(String(feat.properties.id || feat.id), feat);
+                     })
+ 
+-                const features = Array.from(dedupe.values());
++                // If any symbol (point/icon) feature is present, suppress line and fill features
++                // from the result set. This prevents street lines or polygon fills from other
++                // overlays blocking selection of a point icon at the same map location.
++                let features = Array.from(dedupe.values());
++                const hasSymbol = features.some((f) => f.layer.type === 'symbol');
++                if (hasSymbol) {
++                    features = features.filter((f) => f.layer.type === 'symbol');
++                }
+ 
+                 if (!features.length) return;
+ 


### PR DESCRIPTION
## Problem

KMZ/KML point icons (symbol layers) were unselectable when a line or fill layer from another overlay passed through the same map location — for example, a street line from a road network overlay, or a CoT polygon covering the icon's position. Clicking at that location would either open the wrong feature (the road/polygon) or show the multi-select dialogue with unhelpful entries rather than the intended icon.

The root cause is in the `queryRenderedFeatures` click handler in `map.ts`. All clickable overlay layers — symbol, line, and fill — compete equally in the dedupe step. A street line and a point icon from two different overlays have different feature IDs, so both survive deduplication and appear in the results. With `features.length > 1` the multi-select UI opens, burying the icon the user wanted.

## Fix

Two changes to the click handler:

**1. Sort before deduplication** so that when the same feature ID appears in multiple layer types (e.g. a CoT that has both a symbol and a fill layer), the symbol representation wins the Map insert over fill/line:

```typescript
const LAYER_CLICK_PRIORITY = { symbol: 0, line: 1, fill: 2 };
.sort((a, b) => (LAYER_CLICK_PRIORITY[a.layer.type] ?? 3) - (LAYER_CLICK_PRIORITY[b.layer.type] ?? 3))
```

**2. Suppress lines and fills when any symbol is present** in the deduplicated result set:

```typescript
const hasSymbol = features.some((f) => f.layer.type === 'symbol');
if (hasSymbol) features = features.filter((f) => f.layer.type === 'symbol');
```

A user clicking on a point icon never intends to select a road or polygon at the same location. If no symbols are present (click landed only on a road or polygon), lines and fills are returned as normal.

## Behaviour preserved

- Two symbol features close together still trigger the multi-select dialogue as before.
- Clicking on a road or polygon with no icons nearby works exactly as before.
- CoT polygon selection is unaffected when no symbol icons are present at the click point.