### PR TITLE
fix: replace hard WebSocket retry cap with linear backoff and auth failure detection

### DIFF
--- a/api/web/src/base/events.ts
+++ b/api/web/src/base/events.ts
@@ -23,6 +23,7 @@ export enum WorkerMessageType {
 
     Connection_Open = 'connection:open',
     Connection_Close = 'connection:close',
+    Connection_AuthFailure = 'connection:authfailure',
 
     Session_Logout = 'session:logout',
 

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -731,6 +731,9 @@ export const useMapStore = defineStore('cloudtak', {
                     this.isOpen = true;
                 } else if (msg.type === WorkerMessageType.Connection_Close) {
                     this.isOpen = false;
+                } else if (msg.type === WorkerMessageType.Connection_AuthFailure) {
+                    this.isOpen = false;
+                    window.location.href = '/login';
                 } else if (msg.type === WorkerMessageType.Channels_None) {
                     this.hasNoChannels = true;
                 } else if (msg.type === WorkerMessageType.Channels_List) {

--- a/api/web/src/workers/atlas-connection.ts
+++ b/api/web/src/workers/atlas-connection.ts
@@ -10,14 +10,22 @@ import TAKNotification, { NotificationType } from '../base/notification.ts';
 import { WorkerMessageType } from '../base/events.ts';
 import type { Feature, Import, Chat } from '../types.ts';
 
+const RECONNECT_BACKOFF_STEP_MS = 5000;
+const RECONNECT_BACKOFF_MAX_MS = 30000;
+
 export default class AtlasConnection {
     atlas: Atlas;
 
     isDestroyed: boolean;
     isOpen: boolean;
+
+    // Halts reconnection until the user logs in again
+    authFailure: boolean;
+
     ws: WebSocket | undefined;
     reconnectAttempts: number;
-    maxReconnectAttempts: number;
+
+    private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 
     version: string;
 
@@ -26,19 +34,23 @@ export default class AtlasConnection {
 
         this.isDestroyed = false;
         this.isOpen = false;
+        this.authFailure = false;
         this.ws = undefined;
         this.reconnectAttempts = 0;
-        this.maxReconnectAttempts = 5;
+        this.reconnectTimer = undefined;
 
         this.version = version;
     }
 
     reconnect(connection: string) {
         console.log('Forcing WebSocket reconnection...');
-        this.reconnectAttempts = 0;  // Reset counter
+        this.reconnectAttempts = 0;
+        this.authFailure = false;
+        this.clearReconnectTimer();
         if (this.ws) {
             this.ws.close();
         }
+        this.isDestroyed = false;
         this.connect(connection);
     }
 
@@ -57,35 +69,39 @@ export default class AtlasConnection {
             url.protocol = 'wss:';
         }
 
-        this.ws = new WebSocket(url);
+        const ws = new WebSocket(url);
+        this.ws = ws;
 
-        this.ws.addEventListener('open', () => {
+        // A socket that closes without ever opening was rejected during the
+        // HTTP upgrade (401) or never reached the server
+        let opened = false;
+
+        ws.addEventListener('open', () => {
+            if (ws !== this.ws) return;
+
+            opened = true;
+            this.reconnectAttempts = 0;
             this.atlas.postMessage({ type: WorkerMessageType.Connection_Open });
             this.isOpen = true;
-            this.reconnectAttempts = 0;
         });
 
-        this.ws.addEventListener('error', (err) => {
+        ws.addEventListener('error', (err) => {
             console.error(err);
         });
 
-        this.ws.addEventListener('close', () => {
-            this.isOpen = false;
-            this.atlas.postMessage({ type: WorkerMessageType.Connection_Close });
+        ws.addEventListener('close', () => {
+            // A socket superseded by reconnect() must not touch state or
+            // spawn another connection - that's how reconnect loops multiply
+            if (ws !== this.ws) return;
 
-            if (!this.isDestroyed && this.reconnectAttempts < this.maxReconnectAttempts) {
-                this.reconnectAttempts++;
-                const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts - 1), 10000);
-                console.log(`WebSocket reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
-                setTimeout(() => {
-                    if (!this.isDestroyed) this.connect(connection);
-                }, delay);
-            } else if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-                console.error('WebSocket: Max reconnection attempts reached. Please refresh the page.');
-            }
+            this.atlas.postMessage({ type: WorkerMessageType.Connection_Close });
+            this.isOpen = false;
+
+            if (this.isDestroyed || this.authFailure) return;
+            void this.scheduleReconnect(connection, opened);
         });
 
-        this.ws.addEventListener('message', async (msg) => {
+        ws.addEventListener('message', async (msg) => {
             try {
             const body = JSON.parse(msg.data) as {
                 type: string;
@@ -310,8 +326,62 @@ export default class AtlasConnection {
         });
     }
 
+    private async scheduleReconnect(connection: string, opened: boolean): Promise<void> {
+        if (!opened && await this.isAuthRejected()) {
+            this.handleAuthFailure('WebSocket upgrade rejected: session is no longer valid');
+            return;
+        }
+
+        this.reconnectAttempts++;
+        const delay = Math.min(this.reconnectAttempts * RECONNECT_BACKOFF_STEP_MS, RECONNECT_BACKOFF_MAX_MS);
+
+        this.clearReconnectTimer();
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = undefined;
+            if (this.isDestroyed || this.authFailure) return;
+            this.connect(connection);
+        }, delay);
+    }
+
+    private async isAuthRejected(): Promise<boolean> {
+        try {
+            const res = await fetch(stdurl('/api/login'), {
+                headers: { Authorization: `Bearer ${this.atlas.token}` }
+            });
+
+            return res.status === 401;
+        } catch {
+            // Network failure - the server is unreachable, not rejecting us
+            return false;
+        }
+    }
+
+    private handleAuthFailure(message: string): void {
+        if (this.authFailure) return;
+        this.authFailure = true;
+
+        console.error(`WebSocket auth failure: ${message}`);
+
+        this.clearReconnectTimer();
+
+        // The worker cannot clear stored credentials or navigate — the main
+        // thread must route the user to login
+        this.atlas.postMessage({
+            type: WorkerMessageType.Connection_AuthFailure,
+            body: { message }
+        });
+    }
+
+    private clearReconnectTimer(): void {
+        if (this.reconnectTimer !== undefined) {
+            clearTimeout(this.reconnectTimer);
+            this.reconnectTimer = undefined;
+        }
+    }
+
     destroy() {
         this.isDestroyed = true;
+        this.clearReconnectTimer();
 
         if (this.ws) {
             this.ws.close();

--- a/scripts/patches/048-websocket-reconnection-limit.patch
+++ b/scripts/patches/048-websocket-reconnection-limit.patch
@@ -1,60 +1,200 @@
+diff --git a/api/web/src/base/events.ts b/api/web/src/base/events.ts
+index 4c954c968..ff9d29385 100644
+--- a/api/web/src/base/events.ts
++++ b/api/web/src/base/events.ts
+@@ -23,6 +23,7 @@ export enum WorkerMessageType {
+ 
+     Connection_Open = 'connection:open',
+     Connection_Close = 'connection:close',
++    Connection_AuthFailure = 'connection:authfailure',
+ 
+     Session_Logout = 'session:logout',
+ 
+diff --git a/api/web/src/stores/map.ts b/api/web/src/stores/map.ts
+index c7217f7a7..ab81e3418 100644
+--- a/api/web/src/stores/map.ts
++++ b/api/web/src/stores/map.ts
+@@ -731,6 +731,9 @@ export const useMapStore = defineStore('cloudtak', {
+                     this.isOpen = true;
+                 } else if (msg.type === WorkerMessageType.Connection_Close) {
+                     this.isOpen = false;
++                } else if (msg.type === WorkerMessageType.Connection_AuthFailure) {
++                    this.isOpen = false;
++                    window.location.href = '/login';
+                 } else if (msg.type === WorkerMessageType.Channels_None) {
+                     this.hasNoChannels = true;
+                 } else if (msg.type === WorkerMessageType.Channels_List) {
 diff --git a/api/web/src/workers/atlas-connection.ts b/api/web/src/workers/atlas-connection.ts
-index 1234567..abcdefg 100644
+index 3076c209f..f9ae7cbd9 100644
 --- a/api/web/src/workers/atlas-connection.ts
 +++ b/api/web/src/workers/atlas-connection.ts
-@@ -14,6 +14,8 @@ export default class AtlasConnection {
+@@ -10,14 +10,22 @@ import TAKNotification, { NotificationType } from '../base/notification.ts';
+ import { WorkerMessageType } from '../base/events.ts';
+ import type { Feature, Import, Chat } from '../types.ts';
+ 
++const RECONNECT_BACKOFF_STEP_MS = 5000;
++const RECONNECT_BACKOFF_MAX_MS = 30000;
++
+ export default class AtlasConnection {
+     atlas: Atlas;
  
      isDestroyed: boolean;
      isOpen: boolean;
++
++    // Halts reconnection until the user logs in again
++    authFailure: boolean;
++
      ws: WebSocket | undefined;
-+    reconnectAttempts: number;
-+    maxReconnectAttempts: number;
+     reconnectAttempts: number;
+-    maxReconnectAttempts: number;
++
++    private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
  
      version: string;
  
-@@ -23,6 +25,8 @@ export default class AtlasConnection {
+@@ -26,19 +34,23 @@ export default class AtlasConnection {
+ 
          this.isDestroyed = false;
          this.isOpen = false;
++        this.authFailure = false;
          this.ws = undefined;
-+        this.reconnectAttempts = 0;
-+        this.maxReconnectAttempts = 5;
+         this.reconnectAttempts = 0;
+-        this.maxReconnectAttempts = 5;
++        this.reconnectTimer = undefined;
  
          this.version = version;
      }
-@@ -48,6 +52,7 @@ export default class AtlasConnection {
-         this.ws.addEventListener('open', () => {
+ 
+     reconnect(connection: string) {
+         console.log('Forcing WebSocket reconnection...');
+-        this.reconnectAttempts = 0;  // Reset counter
++        this.reconnectAttempts = 0;
++        this.authFailure = false;
++        this.clearReconnectTimer();
+         if (this.ws) {
+             this.ws.close();
+         }
++        this.isDestroyed = false;
+         this.connect(connection);
+     }
+ 
+@@ -57,35 +69,39 @@ export default class AtlasConnection {
+             url.protocol = 'wss:';
+         }
+ 
+-        this.ws = new WebSocket(url);
++        const ws = new WebSocket(url);
++        this.ws = ws;
++
++        // A socket that closes without ever opening was rejected during the
++        // HTTP upgrade (401) or never reached the server
++        let opened = false;
++
++        ws.addEventListener('open', () => {
++            if (ws !== this.ws) return;
+ 
+-        this.ws.addEventListener('open', () => {
++            opened = true;
++            this.reconnectAttempts = 0;
              this.atlas.postMessage({ type: WorkerMessageType.Connection_Open });
              this.isOpen = true;
-+            this.reconnectAttempts = 0;
+-            this.reconnectAttempts = 0;
          });
  
-         this.ws.addEventListener('error', (err) => {
-@@ -55,12 +60,21 @@ export default class AtlasConnection {
+-        this.ws.addEventListener('error', (err) => {
++        ws.addEventListener('error', (err) => {
+             console.error(err);
          });
  
-         this.ws.addEventListener('close', () => {
--            // Otherwise the user is probably logged out
--            if (!this.isDestroyed) {
--                this.connect(connection);
-+            this.isOpen = false;
-+            this.atlas.postMessage({ type: WorkerMessageType.Connection_Close });
-+            
-+            if (!this.isDestroyed && this.reconnectAttempts < this.maxReconnectAttempts) {
-+                this.reconnectAttempts++;
-+                const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts - 1), 10000);
-+                console.log(`WebSocket reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
-+                
-+                setTimeout(() => {
-+                    if (!this.isDestroyed) {
-+                        this.connect(connection);
-+                    }
-+                }, delay);
-+            } else if (this.reconnectAttempts >= this.maxReconnectAttempts) {
-+                console.error('WebSocket: Max reconnection attempts reached. Please refresh the page.');
-             }
--
--            this.atlas.postMessage({ type: WorkerMessageType.Connection_Close });
+-        this.ws.addEventListener('close', () => {
 -            this.isOpen = false;
++        ws.addEventListener('close', () => {
++            // A socket superseded by reconnect() must not touch state or
++            // spawn another connection - that's how reconnect loops multiply
++            if (ws !== this.ws) return;
++
+             this.atlas.postMessage({ type: WorkerMessageType.Connection_Close });
++            this.isOpen = false;
+ 
+-            if (!this.isDestroyed && this.reconnectAttempts < this.maxReconnectAttempts) {
+-                this.reconnectAttempts++;
+-                const delay = Math.min(1000 * Math.pow(2, this.reconnectAttempts - 1), 10000);
+-                console.log(`WebSocket reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
+-                setTimeout(() => {
+-                    if (!this.isDestroyed) this.connect(connection);
+-                }, delay);
+-            } else if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+-                console.error('WebSocket: Max reconnection attempts reached. Please refresh the page.');
+-            }
++            if (this.isDestroyed || this.authFailure) return;
++            void this.scheduleReconnect(connection, opened);
          });
  
-         this.ws.addEventListener('message', async (msg) => {
+-        this.ws.addEventListener('message', async (msg) => {
++        ws.addEventListener('message', async (msg) => {
+             try {
+             const body = JSON.parse(msg.data) as {
+                 type: string;
+@@ -310,8 +326,62 @@ export default class AtlasConnection {
+         });
+     }
+ 
++    private async scheduleReconnect(connection: string, opened: boolean): Promise<void> {
++        if (!opened && await this.isAuthRejected()) {
++            this.handleAuthFailure('WebSocket upgrade rejected: session is no longer valid');
++            return;
++        }
++
++        this.reconnectAttempts++;
++        const delay = Math.min(this.reconnectAttempts * RECONNECT_BACKOFF_STEP_MS, RECONNECT_BACKOFF_MAX_MS);
++
++        this.clearReconnectTimer();
++        this.reconnectTimer = setTimeout(() => {
++            this.reconnectTimer = undefined;
++            if (this.isDestroyed || this.authFailure) return;
++            this.connect(connection);
++        }, delay);
++    }
++
++    private async isAuthRejected(): Promise<boolean> {
++        try {
++            const res = await fetch(stdurl('/api/login'), {
++                headers: { Authorization: `Bearer ${this.atlas.token}` }
++            });
++
++            return res.status === 401;
++        } catch {
++            // Network failure - the server is unreachable, not rejecting us
++            return false;
++        }
++    }
++
++    private handleAuthFailure(message: string): void {
++        if (this.authFailure) return;
++        this.authFailure = true;
++
++        console.error(`WebSocket auth failure: ${message}`);
++
++        this.clearReconnectTimer();
++
++        // The worker cannot clear stored credentials or navigate — the main
++        // thread must route the user to login
++        this.atlas.postMessage({
++            type: WorkerMessageType.Connection_AuthFailure,
++            body: { message }
++        });
++    }
++
++    private clearReconnectTimer(): void {
++        if (this.reconnectTimer !== undefined) {
++            clearTimeout(this.reconnectTimer);
++            this.reconnectTimer = undefined;
++        }
++    }
++
+     destroy() {
+         this.isDestroyed = true;
++        this.clearReconnectTimer();
+ 
+         if (this.ws) {
+             this.ws.close();


### PR DESCRIPTION
## Problem

The previous WebSocket reconnection fix (patch 048) used exponential backoff with a hard cap of 5 attempts, after which it gave up silently. This had two issues:

- After a server restart, clients would stop retrying after ~31 seconds, leaving users with a broken connection until they manually refreshed.
- On session expiry or 401, the client kept retrying until the cap was hit with no indication to the user that their session had expired.

## Changes

This replaces our implementation with upstream's superior strategy, cherry-picked into our codebase without a full sync:

**`atlas-connection.ts`**
- Linear backoff: 5s step, 30s ceiling, no hard retry limit — clients keep retrying indefinitely after a server restart.
- Auth failure detection: `scheduleReconnect()` calls `isAuthRejected()` (`GET /api/login`) when a socket closes before opening. A 401 response sets `authFailure = true`, halts all reconnection, and signals the main thread to redirect to login.
- Stale socket guard: `if (ws !== this.ws) return` in the close handler prevents superseded sockets from spawning new reconnect loops when `reconnect()` forces a new connection.
- `reconnectTimer` is tracked and cleared in `destroy()` so no reconnect fires after teardown.

**`events.ts`**
- Added `Connection_AuthFailure = 'connection:authfailure'` to `WorkerMessageType`.

**`map.ts`**
- Added handler for `Connection_AuthFailure` that sets `isOpen = false` and redirects to `/login`, consistent with the existing `Session_Logout` handler.

## Testing

- Server restart: client should keep retrying every 5–30s and reconnect automatically when the server comes back.
- Session expiry: after a failed WebSocket upgrade (401), the user should be redirected to the login page rather than left in a silent broken state.