### PR TITLE
feat: API key URL authentication for war room display devices

### DIFF
--- a/api/routes/login.ts
+++ b/api/routes/login.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 import Err from '@openaddresses/batch-error';
-import Auth, { AuthUserAccess, oidcParser, isOidcEnabled } from '../lib/auth.js';
+import Auth, { AuthUserAccess, AuthUser, tokenParser, oidcParser, isOidcEnabled } from '../lib/auth.js';
 import Config from '../lib/config.js';
 import Schema from '@openaddresses/batch-schema';
 import { Type } from '@sinclair/typebox';
@@ -100,6 +100,67 @@ export default async function router(schema: Schema, config: Config) {
                 email: profile.username,
                 session: session.id,
                 token: jwt.sign({ access, email: profile.username, s: session.id }, config.SigningSecret, { expiresIn: '16h' }),
+            });
+        } catch (err) {
+            Err.respond(err, res);
+        }
+    });
+
+    await schema.post('/login/token', {
+        name: 'Token Login',
+        group: 'Login',
+        description: 'Exchange a profile-scoped ETL API token for a session JWT for web interface access. Intended for dedicated display devices (war room screens, kiosks) that must authenticate without user interaction.',
+        body: Type.Object({
+            token: Type.String({
+                description: 'ETL API token in etl.<jwt> format',
+            }),
+        }),
+        res: Type.Object({
+            token: Type.String(),
+            access: Type.Enum(AuthUserAccess),
+            email: Type.String(),
+            session: Type.String(),
+        }),
+    }, async (req, res) => {
+        try {
+            const auth = await tokenParser(config, req.body.token, config.SigningSecret);
+
+            // Only profile-scoped tokens can log in to the web interface
+            if (!(auth instanceof AuthUser)) {
+                throw new Err(403, null, 'Only profile-scoped API tokens can be used for web login');
+            }
+
+            const profile = await config.models.Profile.from(auth.email);
+
+            let access = AuthUserAccess.USER;
+            if (profile.system_admin) {
+                access = AuthUserAccess.ADMIN;
+            } else if (profile.agency_admin && profile.agency_admin.length) {
+                access = AuthUserAccess.AGENCY;
+            }
+
+            const userAgent = req.headers['user-agent'] || '';
+            const ua = UAParser(userAgent);
+
+            const session = await config.models.ProfileSession.generate({
+                username: profile.username,
+                created: new Date().toISOString(),
+                ip: String(req.headers['x-forwarded-for'] || req.socket.remoteAddress || 'Unknown'),
+                device_type: ua.device.type || 'Desktop',
+                browser: [ua.browser.name, ua.browser.version].filter(Boolean).join(' ') || 'Unknown',
+                os: [ua.os.name, ua.os.version].filter(Boolean).join(' ') || 'Unknown',
+                user_agent: userAgent,
+            });
+
+            res.json({
+                access,
+                email: profile.username,
+                session: session.id,
+                token: jwt.sign(
+                    { access, email: profile.username, s: session.id },
+                    config.SigningSecret,
+                    { expiresIn: '16h' },
+                ),
             });
         } catch (err) {
             Err.respond(err, res);

--- a/api/web/src/components/Login.vue
+++ b/api/web/src/components/Login.vue
@@ -533,6 +533,33 @@ const certRenewal = reactive<{
 });
 
 onMounted(async () => {
+    // Handle ETL API token passed as URL param for war room / kiosk display use.
+    // These tokens start with 'etl.' and are exchanged for a session JWT via
+    // POST /api/login/token before the normal login flow continues.
+    if (route.query.token && String(route.query.token).startsWith('etl.')) {
+        loading.value = true;
+        loadingMessage.value = 'Authenticating...';
+        const etlToken = String(route.query.token);
+        const redirectPath = route.query.redirect ? String(route.query.redirect) : '/';
+        try {
+            const response = await fetch('/api/login/token', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ token: etlToken }),
+            });
+            if (!response.ok) throw new Error(`Authentication failed: ${response.status}`);
+            const login = await response.json() as { token: string; email: string; session: string };
+            await appStore.persistSession({ token: login.token, username: login.email, session: login.session });
+            emit('login');
+            await router.replace(redirectPath.startsWith('/') ? redirectPath : '/');
+        } catch (err) {
+            loading.value = false;
+            console.error('API token login failed:', err);
+            // Fall through to normal login form
+        }
+        return;
+    }
+
     // Handle token passed back from ALB OIDC redirect (/api/login/oidc → /login?token=xxx)
     if (route.query.token) {
         loading.value = true;

--- a/scripts/patches/065-api-key-url-authentication.patch
+++ b/scripts/patches/065-api-key-url-authentication.patch
@@ -1,0 +1,118 @@
+diff --git a/api/routes/login.ts b/api/routes/login.ts
+index f0766ee7b..65a38696c 100644
+--- a/api/routes/login.ts
++++ b/api/routes/login.ts
+@@ -1,6 +1,6 @@
+ import jwt from 'jsonwebtoken';
+ import Err from '@openaddresses/batch-error';
+-import Auth, { AuthUserAccess, oidcParser, isOidcEnabled } from '../lib/auth.js';
++import Auth, { AuthUserAccess, AuthUser, tokenParser, oidcParser, isOidcEnabled } from '../lib/auth.js';
+ import Config from '../lib/config.js';
+ import Schema from '@openaddresses/batch-schema';
+ import { Type } from '@sinclair/typebox';
+@@ -106,6 +106,67 @@ export default async function router(schema: Schema, config: Config) {
+         }
+     });
+ 
++    await schema.post('/login/token', {
++        name: 'Token Login',
++        group: 'Login',
++        description: 'Exchange a profile-scoped ETL API token for a session JWT for web interface access. Intended for dedicated display devices (war room screens, kiosks) that must authenticate without user interaction.',
++        body: Type.Object({
++            token: Type.String({
++                description: 'ETL API token in etl.<jwt> format',
++            }),
++        }),
++        res: Type.Object({
++            token: Type.String(),
++            access: Type.Enum(AuthUserAccess),
++            email: Type.String(),
++            session: Type.String(),
++        }),
++    }, async (req, res) => {
++        try {
++            const auth = await tokenParser(config, req.body.token, config.SigningSecret);
++
++            // Only profile-scoped tokens can log in to the web interface
++            if (!(auth instanceof AuthUser)) {
++                throw new Err(403, null, 'Only profile-scoped API tokens can be used for web login');
++            }
++
++            const profile = await config.models.Profile.from(auth.email);
++
++            let access = AuthUserAccess.USER;
++            if (profile.system_admin) {
++                access = AuthUserAccess.ADMIN;
++            } else if (profile.agency_admin && profile.agency_admin.length) {
++                access = AuthUserAccess.AGENCY;
++            }
++
++            const userAgent = req.headers['user-agent'] || '';
++            const ua = UAParser(userAgent);
++
++            const session = await config.models.ProfileSession.generate({
++                username: profile.username,
++                created: new Date().toISOString(),
++                ip: String(req.headers['x-forwarded-for'] || req.socket.remoteAddress || 'Unknown'),
++                device_type: ua.device.type || 'Desktop',
++                browser: [ua.browser.name, ua.browser.version].filter(Boolean).join(' ') || 'Unknown',
++                os: [ua.os.name, ua.os.version].filter(Boolean).join(' ') || 'Unknown',
++                user_agent: userAgent,
++            });
++
++            res.json({
++                access,
++                email: profile.username,
++                session: session.id,
++                token: jwt.sign(
++                    { access, email: profile.username, s: session.id },
++                    config.SigningSecret,
++                    { expiresIn: '16h' },
++                ),
++            });
++        } catch (err) {
++            Err.respond(err, res);
++        }
++    });
++
+     await schema.get('/login', {
+         name: 'Get Login',
+         group: 'Login',
+diff --git a/api/web/src/components/Login.vue b/api/web/src/components/Login.vue
+index b8aec8328..e86d8619e 100644
+--- a/api/web/src/components/Login.vue
++++ b/api/web/src/components/Login.vue
+@@ -533,6 +533,33 @@ const certRenewal = reactive<{
+ });
+ 
+ onMounted(async () => {
++    // Handle ETL API token passed as URL param for war room / kiosk display use.
++    // These tokens start with 'etl.' and are exchanged for a session JWT via
++    // POST /api/login/token before the normal login flow continues.
++    if (route.query.token && String(route.query.token).startsWith('etl.')) {
++        loading.value = true;
++        loadingMessage.value = 'Authenticating...';
++        const etlToken = String(route.query.token);
++        const redirectPath = route.query.redirect ? String(route.query.redirect) : '/';
++        try {
++            const response = await fetch('/api/login/token', {
++                method: 'POST',
++                headers: { 'Content-Type': 'application/json' },
++                body: JSON.stringify({ token: etlToken }),
++            });
++            if (!response.ok) throw new Error(`Authentication failed: ${response.status}`);
++            const login = await response.json() as { token: string; email: string; session: string };
++            await appStore.persistSession({ token: login.token, username: login.email, session: login.session });
++            emit('login');
++            await router.replace(redirectPath.startsWith('/') ? redirectPath : '/');
++        } catch (err) {
++            loading.value = false;
++            console.error('API token login failed:', err);
++            // Fall through to normal login form
++        }
++        return;
++    }
++
+     // Handle token passed back from ALB OIDC redirect (/api/login/oidc → /login?token=xxx)
+     if (route.query.token) {
+         loading.value = true;


### PR DESCRIPTION
## Summary

Adds support for authenticating into the CloudTAK web interface via an ETL API token in the URL, with no login form interaction required:

```
https://map.tak.nz/login?token=etl.<jwt>&redirect=/
https://map.tak.nz/login?token=etl.<jwt>&redirect=/#5/-41.29/174.78
```

## Use Case

War room displays, AbleSign screens, Fire TV sticks, and other dedicated wall-mounted devices need to load CloudTAK automatically without user interaction. The URL is configured once on the device and handles authentication silently on every load.

## Changes

**`api/routes/login.ts` — new `POST /api/login/token` endpoint**

Accepts a profile-scoped ETL API token (`etl.<jwt>`), validates it using the existing `tokenParser`, and returns a standard 16h session JWT in the same format as `POST /api/login` and `GET /api/login/oidc`. Resource-scoped and connection-scoped tokens are rejected with 403. A `ProfileSession` record is created for audit purposes, consistent with other login methods.

**`api/web/src/components/Login.vue` — ETL token branch in `onMounted`**

Detects `?token=etl.*` before the existing OIDC token handling, exchanges the token via `POST /api/login/token`, persists the session, and navigates to the `redirect` path. On failure, falls through to the normal login form rather than hanging. All existing login flows (username/password, OIDC, passkey, ALB SSO) are completely unchanged.

## Security

- Token transmitted over HTTPS — equivalent to an `Authorization: Bearer` header
- JWT signature validated server-side via `tokenParser` / `SigningSecret`
- Only `profile`-scoped tokens accepted — resource and connection tokens rejected with 403
- Token visible in server access logs and browser history — acceptable for dedicated display devices where the token is the credential
- Issued session expires in 16h — displays reload automatically to re-authenticate

## Testing

```bash
# Generate a profile-scoped ETL token
TOKEN=$(curl -s -X POST https://map.tak.nz/api/profile/token \
  -H "Authorization: Bearer <session-jwt>" \
  -H "Content-Type: application/json" \
  -d '{"name":"display-test"}' | jq -r .token)

# Verify the exchange endpoint
curl -s -X POST https://map.tak.nz/api/login/token \
  -H "Content-Type: application/json" \
  -d "{\"token\": \"$TOKEN\"}" | jq .

# Open the interface directly — should skip login and load the map
open "https://map.tak.nz/login?token=$TOKEN&redirect=/"
```