### PR TITLE
fix(layer): null out connection_features.layer FK before layer delete

### DIFF
--- a/api/routes/connection-layer.ts
+++ b/api/routes/connection-layer.ts
@@ -22,7 +22,9 @@ import {
     LayerOutgoingResponse,
     LayerUpdateManagementListResponse,
 } from '../lib/types.js';
-import { LayerIncoming, LayerOutgoing } from '../lib/schema.js';
+import {
+    LayerIncoming, LayerOutgoing, ConnectionFeature,
+} from '../lib/schema.js';
 import DataMission from '../lib/data-mission.js';
 import { MAX_LAYERS_IN_DATA_SYNC } from '../lib/data-mission.js';
 import { Layer_Config } from '../lib/models/Layer.js';
@@ -966,6 +968,14 @@ export default async function router(schema: Schema, config: Config) {
             }
 
             config.events.delete(layer.id);
+
+            // Detach any COT features that were written by this layer.
+            // The layer column is nullable so we null it out rather than
+            // deleting the features — they remain on the map but are no
+            // longer associated with a layer.
+            await config.pg.update(ConnectionFeature)
+                .set({ layer: null })
+                .where(eq(ConnectionFeature.layer, layer.id));
 
             await config.models.Layer.delete(req.params.layerid);
 


### PR DESCRIPTION
## Problem

Deleting any layer that has written COT features to the map fails with `Internal Server Error`. The UI shows a generic error with no explanation; the actual cause is a PostgreSQL foreign key constraint violation in the API.

Confirmed on layer 57 ("NZTA Delays2", connection 8), which had 39 rows in `connection_features` referencing `layer = 57`.

## Root cause

The `DELETE /connection/:connectionid/layer/:layerid` handler cleans up child tables before deleting the layer row, but `connection_features` was missing from that sequence:

```typescript
// handled ✓
if (layer.incoming) await config.models.LayerIncoming.delete(req.params.layerid);
if (layer.outgoing) await config.models.LayerOutgoing.delete(req.params.layerid);

// NOT handled ✗ — FK violation if any COT features exist
await config.models.Layer.delete(req.params.layerid);
```

`connection_features.layer` has a FK to `layers.id`. When a layer's Lambda task writes COT features, they accumulate in `connection_features` tagged with that layer ID. `Layer.delete()` then fails with `connection_features_layer_layers_id_fk` constraint violation, which surfaces as a 500.

## Fix

Null out `connection_features.layer` for all features belonging to the layer before deleting the layer row:

```typescript
await config.pg.update(ConnectionFeature)
    .set({ layer: null })
    .where(eq(ConnectionFeature.layer, layer.id));
```

The `layer` column is nullable by design, so this is safe. The COT features remain on the map and in the connection — they just lose their layer association. This is preferable to a hard delete, which would destroy potentially significant operational data.

The connection delete route (which handles a similar FK) takes the harder delete-all approach since it's removing the entire connection. For a layer delete, nulling is the right choice.

---

## Testing

- Build and lint clean (0 errors)
- Layer 57 on connection 8 unblocked — 39 `connection_features` rows will be detached and the layer row deleted cleanly on next attempt