### PR TITLE
chore(nginx): add adss.internal to temporary frame-ancestors allowlist

### DIFF
--- a/api/nginx.conf.js
+++ b/api/nginx.conf.js
@@ -33,9 +33,9 @@ if (url.hostname === 'localhost') {
         'style-src-elem': [`'self'`, `'unsafe-inline'`],
         'style-src-attr': [`'unsafe-inline'`],
         'connect-src': [`'self'`, ...tileOrigins],
-        // TEMPORARY: added to allow CloudTAK to be embedded in https://d2iy9yezumpf3t.cloudfront.net
+        // TEMPORARY: added to allow CloudTAK to be embedded in https://d2iy9yezumpf3t.cloudfront.net and https://adss.internal/
         // Remove the line below when embedding is no longer needed (revert to just 'connect-src' above)
-        'frame-ancestors': [`'self'`, 'https://d2iy9yezumpf3t.cloudfront.net']
+        'frame-ancestors': [`'self'`, 'https://d2iy9yezumpf3t.cloudfront.net', 'https://adss.internal/']
     }
 
     cspstr = `add_header 'Content-Security-Policy' "`


### PR DESCRIPTION
Adds `https://adss.internal/` to the existing temporary `frame-ancestors` CSP directive alongside `https://d2iy9yezumpf3t.cloudfront.net`, allowing CloudTAK to be embedded in both origins.

This is a temporary allowlist — remove both entries (and the `frame-ancestors` directive entirely) once embedding is no longer required.