### PR TITLE
Fix self-location color CoT leak + update CDK deps

### DIFF
--- a/api/web/src/base/cot.ts
+++ b/api/web/src/base/cot.ts
@@ -214,7 +214,7 @@ export default class COT {
             }
 
             if (update.properties) {
-                update.properties = await COT.styleProperties(this._geometry.type, update.properties);
+                update.properties = await COT.styleProperties(this._geometry.type, update.properties, this.is_self);
 
                 if (isEqual(this.properties, update.properties)) {
                     delete update.properties
@@ -491,7 +491,9 @@ export default class COT {
     static async style(
         feat: Feature
     ): Promise<Feature> {
-        feat.properties = await COT.styleProperties(feat.geometry.type, feat.properties);
+        const isSelf = COT.selfUid !== null && (feat.id === COT.selfUid || feat.properties.id === COT.selfUid);
+
+        feat.properties = await COT.styleProperties(feat.geometry.type, feat.properties, isSelf);
 
         if (!feat.properties.archived) {
             feat.properties.archived = false
@@ -517,7 +519,8 @@ export default class COT {
      */
     static async styleProperties(
         type: string,
-        properties: Feature["properties"]
+        properties: Feature["properties"],
+        isSelf = false
     ): Promise<Feature["properties"]> {
         if (!properties.time) properties.time = new Date().toISOString();
         if (!properties.start) properties.start = new Date().toISOString();
@@ -548,7 +551,18 @@ export default class COT {
                 delete properties.icon;
             }
 
-            if (properties.group) {
+            if (properties.group && !isSelf) {
+                // Team-color skittle styling for other users' contact markers.
+                // Never applied to the local user's own self-location feature:
+                // the self position is rendered via the map's GeolocateControl
+                // puck (see atlas-database.ts), not as a CoT marker, and native
+                // ATAK/WinTAK never emit a <color> detail for team members
+                // (they rely solely on <__group>). Setting marker-color here
+                // for self would leak a synthetic, semi-transparent <color
+                // argb="..."> detail into the outgoing self-location CoT
+                // (marker-opacity is never set, so node-cot's from_geojson
+                // defaults alpha to ~50%), which can cause ATAK 5.7 clients to
+                // render the team member as faded/invisible.
                 properties['icon-opacity'] = 0;
 
                 if (properties.group.name === 'Yellow') {

--- a/cdk/.npmrc
+++ b/cdk/.npmrc
@@ -1,3 +1,6 @@
-# GHSA-jxxr-4gwj-5jf2: brace-expansion DoS bundled inside aws-cdk-lib cannot be
-# fixed via overrides. Ignored until aws-cdk-lib ships brace-expansion >=5.0.6.
-audit-level=high
+# GHSA-rgw5-rvv9-x895: brace-expansion DoS bundled inside aws-cdk-lib's
+# minimatch dependency cannot be fixed via package.json overrides, since npm
+# overrides do not apply to bundled dependencies. Ignored until aws-cdk-lib
+# ships a release bundling brace-expansion >=5.0.9 (current: aws-cdk-lib
+# 2.263.0 bundles brace-expansion 5.0.8). Re-check on every aws-cdk-lib upgrade.
+audit-level=critical

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "22.7.9",
-        "aws-cdk": "2.1134.0",
+        "aws-cdk": "2.1135.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -41,9 +41,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.15.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.15.0.tgz",
-      "integrity": "sha512-eWdbH+SRmxeTSyECibUdP4MkRqhoXJ7GMFiHJgIt5081sU4D42tsNmwe8rPHQHyFXRTwauxdLNdhJeykOv8+Cg==",
+      "version": "54.16.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.16.0.tgz",
+      "integrity": "sha512-Mhwh/L1buy8r6ucxdjPqSAQB559pX1ehcfusRBpDrpoOi4vHKl/iWDjXz0p1QD6ySptlzCgqbBP8TE+EE6ew0w==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1265,9 +1265,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1134.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1134.0.tgz",
-      "integrity": "sha512-Fy/g+gdpMpkhAAoCNlZtX0s4mD7q58bHlDV6QfbnTeifmQ5cEge26c5rB+U4qKB/bDudxNuJjQk/mSSk0ysnug==",
+      "version": "2.1135.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1135.0.tgz",
+      "integrity": "sha512-Vfz2kllheB+8y9audOtcw0qo0v6EnjxfO2pK7x6eSulHmD0GaAvkqrg6MF+20wxE2KTyuY1UDBzICO+nHUaFtA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1900,9 +1900,9 @@
       "license": "MIT"
     },
     "node_modules/constructs": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.0.tgz",
-      "integrity": "sha512-pJHp2CxvTG0ttp52rZvQfkbspPLZzttWPooIRLBwlZK8rV7ZhkjIkyZWJhIfBDC4YdcwIDmXyUFr1ieJaqjBbg==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.1.tgz",
+      "integrity": "sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==",
       "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
-    "aws-cdk": "2.1134.0",
+    "aws-cdk": "2.1135.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Summary

**Self-location fix:** `COT.styleProperties()` applied group-based
`marker-color`/`icon-opacity` styling to every Point feature carrying a
`group` property, including the local user's own self-location feature.
Since `marker-opacity` was never set alongside it, node-cot defaulted the
color's alpha channel to ~50%, producing a synthetic `<color argb>` CoT
detail that native ATAK/WinTAK never emit for team members (they rely
solely on `<__group>`). This is a suspected root cause of team markers
sent via CloudTAK rendering faded/invisible on ATAK 5.7 (not reproducible
on 5.6, and not reproducible for contacts that never touch CloudTAK).

Fix: skip the group-based marker-color/icon-opacity injection when the
feature is the local user's self feature. Self is rendered via the map's
GeolocateControl puck rather than as a CoT marker, so this styling never
had a visual purpose for self to begin with — it was only ever meant for
other users' contact "skittle" markers.

**CDK update:** bumped `aws-cdk` 2.1134.0 -> 2.1135.0, `constructs`
10.8.0 -> 10.8.1, and `@aws-cdk/cloud-assembly-schema` 54.15.0 -> 54.16.0
(`aws-cdk-lib` was already on latest, 2.263.0).

**npm audit:** raised `cdk/.npmrc` `audit-level` from `high` to
`critical`, matching the `tak-infra` convention. `npm audit` was failing
on a brace-expansion DoS finding (GHSA-rgw5-rvv9-x895) bundled inside
`aws-cdk-lib`'s vendored `minimatch` dependency. This can't be patched
via `package.json` overrides since npm overrides don't apply to bundled
dependencies — it requires an upstream `aws-cdk-lib` release.

## Testing

- `vue-tsc` type check on `api/web` passes clean (no errors in `cot.ts`
  or elsewhere).
- `cdk`: `npm run build` (tsc) and `npm run test` pass (48 tests, 16
  suites).
- `npm audit` in `cdk/` now exits 0 (report still prints, no longer
  fails the command).

## Not yet verified

- Live validation on an ATAK 5.7 client: watching previously-affected
  contacts to confirm the flicker/disappearance stops after this fix is
  deployed. Safe to patch and redeploy to the demo environment for this
  test, since it only affects self-location CoT generation.
