### PR TITLE
Fix PWA install prompt and icon quality issues

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -102,7 +102,7 @@ jobs:
             ${{ steps.tags.outputs.ecr-repo-uri }}
       
       - name: Install Branding Dependencies
-        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
+        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin imagemagick
       
       - name: Apply Branding (Conditional)
         run: |

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -97,7 +97,7 @@ jobs:
             ${{ steps.tags.outputs.ecr-repo-uri }}
       
       - name: Install Branding Dependencies
-        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin
+        run: sudo apt-get update && sudo apt-get install -y librsvg2-bin imagemagick
       
       - name: Apply Branding (Conditional)
         run: |

--- a/api/lib/logos.ts
+++ b/api/lib/logos.ts
@@ -6,13 +6,13 @@ export const LOGO_SIZES = [192, 512];
 export async function buildLogos(config: Config): Promise<Map<number, Buffer>> {
     const logos = new Map<number, Buffer>();
 
-    let logoData: string | undefined;
-    try {
-        const setting = await config.models.Setting.from('login::logo');
-        logoData = String(setting.value);
-    } catch {
-        // No custom logo configured
-    }
+    // Setting.typed() falls back to FullConfigDefaults['login::logo'] (the
+    // build-time CloudTAKLogo.svg, which branding overwrites) when no admin
+    // override is stored in the DB. Using the raw Setting.from() here
+    // instead - as this previously did - meant a fresh deployment with no
+    // DB row got an empty icon set in the PWA manifest, since from() throws
+    // rather than applying the default.
+    const { value: logoData } = await config.models.Setting.typed('login::logo');
 
     if (!logoData) return logos;
 

--- a/api/test/manifest.srv.test.ts
+++ b/api/test/manifest.srv.test.ts
@@ -12,7 +12,7 @@ flight.takeoff();
 flight.user();
 flight.server('admin@example.com', 'password123');
 
-test('GET: /api/manifest.webmanifest - no logo configured', async () => {
+test('GET: /api/manifest.webmanifest - no logo configured, falls back to default', async () => {
     try {
         const res = await flight.fetch('/api/manifest.webmanifest', {
             method: 'GET',
@@ -24,7 +24,10 @@ test('GET: /api/manifest.webmanifest - no logo configured', async () => {
         assert.equal(res.body.display, 'standalone');
         assert.equal(res.body.start_url, '/');
         assert.ok(Array.isArray(res.body.icons), 'icons is array');
-        assert.equal(res.body.icons.length, 0, 'no icons when logo not configured');
+        // With no 'login::logo' row in the DB, buildLogos() falls back to
+        // FullConfigDefaults['login::logo'] (CloudTAKLogo.svg), so a fresh
+        // deployment still gets a valid icon set instead of an empty array.
+        assert.equal(res.body.icons.length, 2, 'default logo produces two icons (192 and 512)');
     } catch (err) {
         assert.ifError(err);
     }

--- a/api/web/admin.html
+++ b/api/web/admin.html
@@ -12,13 +12,14 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no">
 
+        <link rel="manifest" href="/api/manifest.webmanifest" />
 
         <!-- iOS PWA Settings: ref: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html?ref=frontendchecklist -->
         <meta name="format-detection" content="telephone=no">
-        <link rel="apple-touch-icon" href="./public/logos/512.png">
-        <link rel="apple-touch-icon" sizes="152x152" href="/logos/152.png">
-        <link rel="apple-touch-icon" sizes="180x180" href="/logos/180.png">
-        <link rel="apple-touch-icon" sizes="167x167" href="/logos/167.png">
+        <link rel="apple-touch-icon" href="/logos/ios/512.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="/logos/ios/152.png">
+        <link rel="apple-touch-icon" sizes="180x180" href="/logos/ios/180.png">
+        <link rel="apple-touch-icon" sizes="167x167" href="/logos/ios/167.png">
 
         <title>CloudTAK Admin</title>
     </head>

--- a/api/web/connection.html
+++ b/api/web/connection.html
@@ -12,13 +12,14 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no">
 
+        <link rel="manifest" href="/api/manifest.webmanifest" />
 
         <!-- iOS PWA Settings: ref: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html?ref=frontendchecklist -->
         <meta name="format-detection" content="telephone=no">
-        <link rel="apple-touch-icon" href="./public/logos/512.png">
-        <link rel="apple-touch-icon" sizes="152x152" href="/logos/152.png">
-        <link rel="apple-touch-icon" sizes="180x180" href="/logos/180.png">
-        <link rel="apple-touch-icon" sizes="167x167" href="/logos/167.png">
+        <link rel="apple-touch-icon" href="/logos/ios/512.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="/logos/ios/152.png">
+        <link rel="apple-touch-icon" sizes="180x180" href="/logos/ios/180.png">
+        <link rel="apple-touch-icon" sizes="167x167" href="/logos/ios/167.png">
 
         <title>CloudTAK Connection</title>
     </head>

--- a/api/web/docs.html
+++ b/api/web/docs.html
@@ -5,13 +5,14 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no">
 
+        <link rel="manifest" href="/api/manifest.webmanifest" />
 
         <!-- iOS PWA Settings: ref: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html?ref=frontendchecklist -->
         <meta name="format-detection" content="telephone=no">
-        <link rel="apple-touch-icon" href="./public/logos/512.png">
-        <link rel="apple-touch-icon" sizes="152x152" href="/logos/152.png">
-        <link rel="apple-touch-icon" sizes="180x180" href="/logos/180.png">
-        <link rel="apple-touch-icon" sizes="167x167" href="/logos/167.png">
+        <link rel="apple-touch-icon" href="/logos/ios/512.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="/logos/ios/152.png">
+        <link rel="apple-touch-icon" sizes="180x180" href="/logos/ios/180.png">
+        <link rel="apple-touch-icon" sizes="167x167" href="/logos/ios/167.png">
 
         <title>CloudTAK</title>
     </head>

--- a/api/web/index.html
+++ b/api/web/index.html
@@ -16,10 +16,10 @@
 
         <!-- iOS PWA Settings: ref: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html?ref=frontendchecklist -->
         <meta name="format-detection" content="telephone=no">
-        <link rel="apple-touch-icon" href="./public/logos/512.png">
-        <link rel="apple-touch-icon" sizes="152x152" href="/logos/152.png">
-        <link rel="apple-touch-icon" sizes="180x180" href="/logos/180.png">
-        <link rel="apple-touch-icon" sizes="167x167" href="/logos/167.png">
+        <link rel="apple-touch-icon" href="/logos/ios/512.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="/logos/ios/152.png">
+        <link rel="apple-touch-icon" sizes="180x180" href="/logos/ios/180.png">
+        <link rel="apple-touch-icon" sizes="167x167" href="/logos/ios/167.png">
 
         <title>CloudTAK</title>
     </head>

--- a/api/web/setup.html
+++ b/api/web/setup.html
@@ -11,11 +11,13 @@
         <meta http-equiv='X-UA-Compatible' content='IE=edge'>
         <meta name='viewport' content='width=device-width,initial-scale=1.0,user-scalable=no'>
 
+        <link rel='manifest' href='/api/manifest.webmanifest' />
+
         <meta name='format-detection' content='telephone=no'>
-        <link rel='apple-touch-icon' href='/logos/512.png'>
-        <link rel='apple-touch-icon' sizes='152x152' href='/logos/152.png'>
-        <link rel='apple-touch-icon' sizes='180x180' href='/logos/180.png'>
-        <link rel='apple-touch-icon' sizes='167x167' href='/logos/167.png'>
+        <link rel='apple-touch-icon' href='/logos/ios/512.png'>
+        <link rel='apple-touch-icon' sizes='152x152' href='/logos/ios/152.png'>
+        <link rel='apple-touch-icon' sizes='180x180' href='/logos/ios/180.png'>
+        <link rel='apple-touch-icon' sizes='167x167' href='/logos/ios/167.png'>
 
         <title>CloudTAK Setup</title>
     </head>

--- a/api/web/video.html
+++ b/api/web/video.html
@@ -5,13 +5,14 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=no">
 
+        <link rel="manifest" href="/api/manifest.webmanifest" />
 
         <!-- iOS PWA Settings: ref: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html?ref=frontendchecklist -->
         <meta name="format-detection" content="telephone=no">
-        <link rel="apple-touch-icon" href="./public/logos/512.png">
-        <link rel="apple-touch-icon" sizes="152x152" href="/logos/152.png">
-        <link rel="apple-touch-icon" sizes="180x180" href="/logos/180.png">
-        <link rel="apple-touch-icon" sizes="167x167" href="/logos/167.png">
+        <link rel="apple-touch-icon" href="/logos/ios/512.png">
+        <link rel="apple-touch-icon" sizes="152x152" href="/logos/ios/152.png">
+        <link rel="apple-touch-icon" sizes="180x180" href="/logos/ios/180.png">
+        <link rel="apple-touch-icon" sizes="167x167" href="/logos/ios/167.png">
 
         <title>CloudTAK</title>
     </head>

--- a/branding/generate_icons.sh
+++ b/branding/generate_icons.sh
@@ -18,6 +18,16 @@ if [ ! -f "$SVG_SOURCE" ]; then
     exit 1
 fi
 
+if ! command -v rsvg-convert &> /dev/null; then
+    echo "Error: rsvg-convert not found (install librsvg2-bin)"
+    exit 1
+fi
+
+if ! command -v convert &> /dev/null; then
+    echo "Error: convert not found (install imagemagick)"
+    exit 1
+fi
+
 # Function to extract width from size string (e.g., "48x48" -> "48")
 get_width() {
     local size="$1"
@@ -56,17 +66,27 @@ while IFS= read -r line; do
         
         # Generate the icon
         echo "Generating: $output_path (${width}x${height})"
-        
-        if [ "$width" = "$height" ]; then
-            # Square icon - use width only
-            rsvg-convert -w "$width" "$SVG_SOURCE" > "$output_path"
-        else
-            # Non-square icon - specify both width and height
-            rsvg-convert -w "$width" -h "$height" "$SVG_SOURCE" > "$output_path"
-        fi
-        
-        # Check if the conversion was successful
-        if [ $? -eq 0 ]; then
+
+        # The source SVG's viewBox isn't perfectly square (1024x1039.657).
+        # Passing only -w (as before) let rsvg-convert derive height from
+        # the source ratio, silently producing e.g. a 512x520 image for a
+        # "512x512" icon slot - every generated icon was slightly squashed.
+        #
+        # Fix: render with --keep-aspect-ratio (-a), which scales the logo
+        # to fit within the target box without distortion, then pad the
+        # result onto a transparent canvas of the exact target size with
+        # ImageMagick. This guarantees the output canvas always matches the
+        # size declared in icons.ts, for both square and non-square targets
+        # (e.g. Windows tile logos).
+        rm -f "$output_path"
+        rsvg-convert -w "$width" -h "$height" -a "$SVG_SOURCE" | \
+            convert - -background none -gravity center -extent "${width}x${height}" "$output_path"
+
+        # This inner pipeline runs inside an outer `... | while` pipeline, so
+        # PIPESTATUS here would reflect the outer pipeline's stages, not
+        # rsvg-convert/convert. Check the output file was actually written
+        # instead.
+        if [ -s "$output_path" ]; then
             echo "✓ Successfully generated: $output_path"
         else
             echo "✗ Failed to generate: $output_path"


### PR DESCRIPTION
## Summary

Fixes three related issues causing poor PWA behavior on a TAK.NZ-branded deployment: no install prompt in Chrome, low-quality Android home-screen icons, and squashed/broken icons in general.

## Problems

1. **Empty PWA manifest icons on fresh deployments.** `buildLogos()` read `login::logo` with the raw `Setting.from()`, which throws when no DB row exists — unlike every other config read in the app (`Setting.typed()`/`typedKeys()`), which falls back to `FullConfigDefaults`. Since `apply-branding.sh` never writes a `login::logo` DB row, `/api/manifest.webmanifest` shipped `icons: []` on every fresh TAK.NZ deployment. No valid manifest icon means Chrome never offers the install prompt, and Android falls back to an auto-generated icon on "Add to Home Screen" — explaining the reported poor icon quality.

2. **Squashed generated icons.** `branding/generate_icons.sh` rendered icons with `rsvg-convert -w <N>` alone. The source SVG's viewBox isn't square (`1024x1039.657`), so rsvg derived height from the source ratio instead of the declared target size — every generated icon (iOS, Android, Windows tiles) was silently squashed by 1-3% (e.g. a "512x512" icon actually rendered at 512x520).

3. **Broken iOS icon links.** Every entry HTML page's `apple-touch-icon` hrefs pointed at `./public/logos/512.png` / `/logos/152.png`, neither of which exist — the real files live under `/logos/ios/`. This was fixed upstream once (commit `09a84f924`) but regressed in a later sync. Additionally, `admin.html`, `connection.html`, `docs.html`, `video.html`, and `setup.html` had no `<link rel="manifest">` at all, so those routes (opened as their own tab via `openSecondaryView()`) never offered installation directly, unlike `index.html`.

## Changes

- `api/lib/logos.ts`: use `Setting.typed('login::logo')` instead of `Setting.from()` so the build-time `CloudTAKLogo.svg` default is used until an admin sets a custom logo.
- `branding/generate_icons.sh`: render via `rsvg-convert -a` (fit, preserve aspect ratio) piped into `convert -gravity center -extent WxH` (pad to exact canvas). Added an upfront dependency check for `rsvg-convert`/`convert`.
- `.github/workflows/{demo,production}-build.yml`: install `imagemagick` alongside `librsvg2-bin` for the branding step.
- `api/web/*.html`: corrected all `apple-touch-icon` hrefs to `/logos/ios/<size>.png`; added `<link rel="manifest">` to `admin.html`, `connection.html`, `docs.html`, `video.html`, `setup.html`.
- `api/test/manifest.srv.test.ts`: updated the "no logo configured" test to expect the default-backed icon set (2 icons) instead of an empty array.

## Testing

- Regenerated all 112 icons declared in `icons.ts` and verified every one now matches its declared canvas size exactly (previously ~106 were off by 1-3%), with content aspect ratio preserved (no stretching).
- Ran `api/test/manifest.srv.test.ts` against a local Postgres/PostGIS instance — all 11 tests pass, confirming the manifest returns valid icons both with and without a `login::logo` DB override.
- Verified with a production Vite build that all six compiled HTML entry points carry the corrected icon paths and manifest link.
- Locally regenerated icon PNGs were **not** committed — `generate_icons.sh` runs at Docker build time via `apply-branding.sh`, so the script/workflow fix is sufficient; committing regenerated binaries here would just be build output.