### PR TITLE
fix(pwa): empty-string logo fallback + Node24 actions + any-type cleanup

### DIFF
--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -17,14 +17,14 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'npm'
         cache-dependency-path: 'cdk/package-lock.json'
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -29,7 +29,7 @@ jobs:
       - run: echo "👾 Repository is ${{ github.repository }}."
       
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -40,7 +40,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
             node-version: '22'
             registry-url: https://registry.npmjs.org/

--- a/.github/workflows/cloudtak-test.yml
+++ b/.github/workflows/cloudtak-test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Docker API Build
         run: docker buildx build ./api -t cloudtak-api
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
@@ -54,9 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/
@@ -81,9 +81,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -47,7 +47,7 @@ jobs:
       cloudtak-tag: ${{ steps.tags.outputs.cloudtak-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
 
         
@@ -119,7 +119,7 @@ jobs:
           fi
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Build and Push CloudTAK Images
         run: |

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -39,7 +39,7 @@ jobs:
     needs: [cdk-test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
@@ -72,7 +72,7 @@ jobs:
       cloudtak-tag: ${{ steps.images.outputs.cloudtak-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
@@ -122,7 +122,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -44,7 +44,7 @@ jobs:
       cloudtak-tag: ${{ steps.tags.outputs.cloudtak-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
@@ -114,7 +114,7 @@ jobs:
           fi
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       
       - name: Build and Push CloudTAK Images
         run: |

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     needs: [cdk-test, cloudtak-test, build-images]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch full history for changelog generation
 
@@ -66,7 +66,7 @@ jobs:
           echo "🚀 **Deployment:** This release will trigger production deployment after approval." >> RELEASE_NOTES.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: RELEASE_NOTES.md
           generate_release_notes: true  # GitHub will append auto-generated notes

--- a/.github/workflows/weekly-sync.yml
+++ b/.github/workflows/weekly-sync.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0

--- a/api/lib/logos.ts
+++ b/api/lib/logos.ts
@@ -1,5 +1,6 @@
 import Config from './config.js';
 import sharp from 'sharp';
+import { FullConfigDefaults } from './defaults.js';
 
 export const LOGO_SIZES = [192, 512];
 
@@ -12,12 +13,20 @@ export async function buildLogos(config: Config): Promise<Map<number, Buffer>> {
     // instead - as this previously did - meant a fresh deployment with no
     // DB row got an empty icon set in the PWA manifest, since from() throws
     // rather than applying the default.
+    //
+    // typed() only substitutes the default when the row is entirely
+    // absent. A DB row that exists but holds an empty string (e.g. an
+    // admin cleared a previously-set custom logo via the Admin UI) is
+    // returned as-is, so `logoData` can still be '' here. Treat that the
+    // same as "unset" and fall back to the default logo, rather than
+    // shipping an empty icon set that blocks the PWA install prompt.
     const { value: logoData } = await config.models.Setting.typed('login::logo');
+    const effectiveLogoData = logoData || FullConfigDefaults['login::logo'];
 
-    if (!logoData) return logos;
+    if (!effectiveLogoData) return logos;
 
     // Strip data URL prefix and decode base64
-    const base64Match = logoData.match(/^data:[^;]+;base64,(.+)$/);
+    const base64Match = effectiveLogoData.match(/^data:[^;]+;base64,(.+)$/);
     if (!base64Match) return logos;
 
     const inputBuffer = Buffer.from(base64Match[1], 'base64');

--- a/api/test/manifest.srv.test.ts
+++ b/api/test/manifest.srv.test.ts
@@ -70,6 +70,39 @@ test('GET: /api/manifest.webmanifest - logo configured', async () => {
     }
 });
 
+test('PUT: /api/config - clear login logo to empty string', async () => {
+    try {
+        const res = await flight.fetch('/api/config', {
+            method: 'PUT',
+            auth: { bearer: flight.token.admin },
+            body: { 'login::logo': '' },
+        }, false);
+
+        assert.equal(res.status, 200, 'http 200');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
+test('GET: /api/manifest.webmanifest - empty-string logo row falls back to default', async () => {
+    try {
+        const res = await flight.fetch('/api/manifest.webmanifest', {
+            method: 'GET',
+        }, true);
+
+        assert.equal(res.status, 200, 'http 200');
+        assert.ok(Array.isArray(res.body.icons), 'icons is array');
+        // A DB row that exists but is '' (e.g. an admin cleared a custom
+        // logo) must not be treated as "logo configured" - it should fall
+        // back to the default logo just like a missing row, otherwise the
+        // PWA manifest ships an empty icon set and blocks the install
+        // prompt.
+        assert.equal(res.body.icons.length, 2, 'default logo produces two icons (192 and 512)');
+    } catch (err) {
+        assert.ifError(err);
+    }
+});
+
 test('GET: /api/manifest.webmanifest/logos/192', async () => {
     try {
         const res = await flight.fetch('/api/manifest.webmanifest/logos/192', {

--- a/tasks/pmtiles/lib/tiles.ts
+++ b/tasks/pmtiles/lib/tiles.ts
@@ -89,6 +89,47 @@ export const RasterTileSource = Type.Object({
     maxzoom: Type.Integer(),
 });
 
+// pmtiles' PMTiles#getMetadata() is typed as Promise<unknown> since the
+// PMTiles spec places no constraints on metadata contents. CloudTAK only
+// ever reads `vector_layers` off of it (mirrored into the TileJSON
+// response below), so narrow just that shape rather than casting to `any`.
+interface PMTilesMetadata {
+    vector_layers?: Static<typeof TileJSON>['vector_layers'];
+}
+
+// Minimal shape of the callback response from @mapbox/vtquery - the module
+// ships no type definitions (see the `@ts-expect-error` import above), so
+// this documents the fields this file actually reads/writes on it.
+interface VtQueryFeatureCollection {
+    type: 'FeatureCollection';
+    features: object[];
+    query?: unknown;
+    meta?: unknown;
+}
+
+/**
+ * Split a Multi* GeoJSON feature (MultiPoint/MultiLineString/MultiPolygon)
+ * into one single-geometry feature per member, used when `opts.multi ===
+ * false`. Shared by `features()` and `featuresByBounds()`.
+ */
+function splitMultiGeometryFeature(geojson: GeoJSON.Feature): GeoJSON.Feature[] {
+    const type = geojson.geometry.type.replace('Multi', '') as GeoJSON.Geometry['type'];
+    const coordinates = (geojson.geometry as GeoJSON.MultiPoint | GeoJSON.MultiLineString | GeoJSON.MultiPolygon).coordinates;
+
+    return coordinates.map((coord): GeoJSON.Feature => {
+        const feat = {
+            type: 'Feature',
+            properties: geojson.properties,
+            geometry: {
+                type: type,
+                coordinates: coord,
+            },
+        } as GeoJSON.Feature;
+        if (geojson.id) feat.id = geojson.id;
+        return feat;
+    });
+}
+
 export class FileTiles {
     path: string;
 
@@ -125,7 +166,7 @@ export class FileTiles {
     ): Promise<Static<typeof TileJSON>> {
         const p = new pmtiles.PMTiles(new S3Source(this.path), CACHE, nativeDecompress);
         const header = await p.getHeader();
-        const metadata = await p.getMetadata() as any;
+        const metadata = await p.getMetadata() as PMTilesMetadata;
         const source = await this.rasterTileSource(token);
 
         return {
@@ -201,15 +242,12 @@ export class FileTiles {
                 features: [],
             };
         } else {
-            const fc: any = await new Promise((resolve, reject) => {
+            const fc = await new Promise<VtQueryFeatureCollection>((resolve, reject) => {
                 vtquery([
                     { buffer: tile.data, z: xyz[2], x: xyz[0], y: xyz[1] },
                 ], query.lnglat, {
                     limit: query.limit,
-                }, (err: Error, fc: {
-                    type: string;
-                    features: object[];
-                }) => {
+                }, (err: Error, fc: VtQueryFeatureCollection) => {
                     if (err) return reject(err);
                     return resolve(fc);
                 });
@@ -218,7 +256,7 @@ export class FileTiles {
             fc.query = query;
             fc.meta = meta;
 
-            return fc;
+            return fc as Static<typeof QueryResponse>;
         }
     }
 
@@ -265,7 +303,7 @@ export class FileTiles {
             };
         }
 
-        const features: any[] = [];
+        const features: GeoJSON.Feature[] = [];
 
         if (header.tileType === pmtiles.TileType.Mvt) {
             const tile = new VectorTile(new Pbf(tile_result.data));
@@ -281,20 +319,7 @@ export class FileTiles {
                     const geojson = feature.toGeoJSON(x, y, z);
 
                     if (opts.multi === false && geojson.geometry.type.startsWith('Multi')) {
-                        const type = geojson.geometry.type.replace('Multi', '');
-                        const coordinates = (geojson.geometry as any).coordinates;
-
-                        for (const coord of coordinates) {
-                            const feat: any = {
-                                type: 'Feature',
-                                properties: geojson.properties,
-                                geometry: {
-                                    type: type,
-                                    coordinates: coord,
-                                },
-                            };
-                            if (geojson.id) feat.id = geojson.id;
-
+                        for (const feat of splitMultiGeometryFeature(geojson)) {
                             if (opts.type && feat.geometry.type !== opts.type) continue;
                             features.push(feat);
                         }
@@ -311,7 +336,7 @@ export class FileTiles {
         return {
             type: 'FeatureCollection',
             features: features,
-        };
+        } as Static<typeof FeaturesResponse>;
     }
 
     /**
@@ -365,7 +390,7 @@ export class FileTiles {
                 const tile_result = await p.getZxy(z, x, y);
                 if (!tile_result) return [];
 
-                const features: any[] = [];
+                const features: GeoJSON.Feature[] = [];
 
                 const tile = new VectorTile(new Pbf(tile_result.data));
 
@@ -380,20 +405,7 @@ export class FileTiles {
                         const geojson = feature.toGeoJSON(x, y, z);
 
                         if (opts.multi === false && geojson.geometry.type.startsWith('Multi')) {
-                            const type = geojson.geometry.type.replace('Multi', '');
-                            const coordinates = (geojson.geometry as any).coordinates;
-
-                            for (const coord of coordinates) {
-                                const feat: any = {
-                                    type: 'Feature',
-                                    properties: geojson.properties,
-                                    geometry: {
-                                        type: type,
-                                        coordinates: coord,
-                                    },
-                                };
-                                if (geojson.id) feat.id = geojson.id;
-
+                            for (const feat of splitMultiGeometryFeature(geojson)) {
                                 if (opts.type && feat.geometry.type !== opts.type) continue;
                                 features.push(feat);
                             }
@@ -407,7 +419,7 @@ export class FileTiles {
                 return features;
             });
 
-        const features: any[] = [];
+        const features: GeoJSON.Feature[] = [];
         for (const result of results) {
             features.push(...result);
         }
@@ -415,7 +427,7 @@ export class FileTiles {
         return {
             type: 'FeatureCollection',
             features: features,
-        };
+        } as Static<typeof FeaturesResponse>;
     }
 
     /**

--- a/tasks/pmtiles/test/basemap-elevation.srv.test.ts
+++ b/tasks/pmtiles/test/basemap-elevation.srv.test.ts
@@ -3,13 +3,14 @@ import assert from 'node:assert/strict';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import type { AddressInfo } from 'net';
+import type { Express } from 'express';
 import { PNG } from 'pngjs';
 
 process.env.SigningSecret = 'test-secret';
 process.env.ASSET_BUCKET = 'test-bucket';
 process.env.API_URL = 'http://localhost:5001';
 
-let app: any;
+let app: Express;
 let server: http.Server;
 
 function createTile(elevation: number): ArrayBuffer {

--- a/tasks/pmtiles/test/profile-elevation.srv.test.ts
+++ b/tasks/pmtiles/test/profile-elevation.srv.test.ts
@@ -3,14 +3,16 @@ import assert from 'node:assert/strict';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import type { AddressInfo } from 'net';
+import type { Express } from 'express';
 import { PNG } from 'pngjs';
+import type { FileTiles as FileTilesClass } from '../lib/tiles.js';
 
 process.env.SigningSecret = 'test-secret';
 process.env.ASSET_BUCKET = 'test-bucket';
 
-let app: any;
+let app: Express;
 let server: http.Server;
-let FileTiles: any;
+let FileTiles: typeof FileTilesClass;
 
 function createTile(elevation: number): ArrayBuffer {
     const png = new PNG({ width: 4, height: 4 });

--- a/tasks/pmtiles/test/profile.srv.test.ts
+++ b/tasks/pmtiles/test/profile.srv.test.ts
@@ -3,12 +3,13 @@ import assert from 'node:assert';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import type { AddressInfo } from 'net';
+import type { Express } from 'express';
 
 // Set env vars before importing app
 process.env.SigningSecret = 'test-secret';
 process.env.ASSET_BUCKET = 'test-bucket';
 
-let app: any;
+let app: Express;
 let server: http.Server;
 
 function getAddress(): string {

--- a/tasks/pmtiles/test/public-elevation.srv.test.ts
+++ b/tasks/pmtiles/test/public-elevation.srv.test.ts
@@ -3,14 +3,16 @@ import assert from 'node:assert/strict';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import type { AddressInfo } from 'net';
+import type { Express } from 'express';
 import { PNG } from 'pngjs';
+import type { FileTiles as FileTilesClass } from '../lib/tiles.js';
 
 process.env.SigningSecret = 'test-secret';
 process.env.ASSET_BUCKET = 'test-bucket';
 
-let app: any;
+let app: Express;
 let server: http.Server;
-let FileTiles: any;
+let FileTiles: typeof FileTilesClass;
 
 function createTile(elevation: number): Uint8Array {
     const png = new PNG({ width: 4, height: 4 });

--- a/tasks/pmtiles/test/routes-profile.test.ts
+++ b/tasks/pmtiles/test/routes-profile.test.ts
@@ -3,12 +3,13 @@ import assert from 'node:assert';
 import jwt from 'jsonwebtoken';
 import http from 'http';
 import type { AddressInfo } from 'net';
+import type { Express } from 'express';
 
 // Set env vars before importing app
 process.env.SigningSecret = 'test-secret';
 process.env.ASSET_BUCKET = 'test-bucket';
 
-let app: any;
+let app: Express;
 let server: http.Server;
 
 function getAddress(): string {


### PR DESCRIPTION
## Summary
- Fixes the demo deployment's PWA install prompt/missing logos bug: `buildLogos()` fell back to the default logo only when the `login::logo` Setting row was entirely absent, not when it exists but is an empty string (the actual state on `map.demo.tak.nz`, likely from a previously-cleared custom logo). Now falls back to `FullConfigDefaults['login::logo']` in both cases.
- Bumps all GitHub Actions to Node 24 runtime majors to clear the Node 20 deprecation warnings: `actions/checkout@v5`, `actions/setup-node@v6`, `aws-actions/configure-aws-credentials@v6`, `docker/setup-buildx-action@v4`, `softprops/action-gh-release@v3`.
- Fixes `@typescript-eslint/no-explicit-any` warnings flagged in CI for `tasks/pmtiles` (`lib/tiles.ts` and several test files) by properly typing PMTiles metadata, the untyped `@mapbox/vtquery` callback, and GeoJSON feature arrays.

## Testing
- `tsc --noEmit` and `eslint` clean on all touched files (api and tasks/pmtiles).
- Added a regression test in `api/test/manifest.srv.test.ts` covering the empty-string `login::logo` case.
- Ran the full `tasks/pmtiles` test suite (17/17 passing).
- Could not run `api`'s test suite locally (requires a local Postgres instance not available in this environment); verified the fixed fallback logic with a standalone script exercising the exact resize path for all three cases (missing/empty/custom logo).
- Validated all workflow YAML with `yaml.safe_load` after the version bumps.

This branch was split out from a separate in-progress OIDC/login branch so it can merge independently.