### PR TITLE
fix(cdk): simplify CLOUDTAK_Server_name for prod vs dev-test

### DIFF
--- a/cdk/lib/constructs/cloudtak-api.ts
+++ b/cdk/lib/constructs/cloudtak-api.ts
@@ -423,7 +423,7 @@ export class CloudTakApi extends Construct {
         'SubnetPublicB': cdk.Fn.importValue(createBaseImportValue(envConfig.stackName, BASE_EXPORT_NAMES.SUBNET_PUBLIC_B)),
         'MediaSecurityGroup': mediaSecurityGroup.securityGroupId,
         // CloudTAK Server configuration
-        'CLOUDTAK_Server_name': `TAK.NZ ${environment === 'prod' ? 'Production' : 'Development'} Server`,
+        'CLOUDTAK_Server_name': environment === 'prod' ? 'TAK.NZ' : `TAK.NZ ${envConfig.stackName}`,
         'CLOUDTAK_Server_url': `ssl://${cdk.Fn.importValue(createTakImportValue(envConfig.stackName, TAK_EXPORT_NAMES.TAK_SERVICE_NAME))}:8089`,
         'CLOUDTAK_Server_api': `https://${cdk.Fn.importValue(createTakImportValue(envConfig.stackName, TAK_EXPORT_NAMES.TAK_SERVICE_NAME))}:8443`,
         'CLOUDTAK_Server_webtak': `https://${cdk.Fn.importValue(createTakImportValue(envConfig.stackName, TAK_EXPORT_NAMES.TAK_SERVICE_NAME))}:8446`,


### PR DESCRIPTION
### Summary

Changes the `CLOUDTAK_Server_name` env var label:

| Environment | Before | After |
|---|---|---|
| `prod` | `TAK.NZ Production Server` | `TAK.NZ` |
| `dev-test` | `TAK.NZ Development Server` | `TAK.NZ <stackName>` (e.g. `TAK.NZ Demo`) |

Prod gets a cleaner, simpler name. Dev-test now shows the actual stack name instead of a generic "Development" label, so multiple dev-test stacks are distinguishable by server name in the CloudTAK UI.

### Changes

- `cdk/lib/constructs/cloudtak-api.ts` — one-line change to the `CLOUDTAK_Server_name` value passed to the API container's environment.

### Testing

- `npx tsc --noEmit` — clean, no diagnostics.
- Not yet deployed/verified against a live environment — this is a straightforward string change with no logic branches beyond the existing `environment === 'prod'` check, so no functional risk beyond the displayed name itself.