### PR TITLE
fix(login): consume the OIDC session URL fragment on the frontend

### DIFF
--- a/api/web/src/components/Login.vue
+++ b/api/web/src/components/Login.vue
@@ -533,6 +533,61 @@ const certRenewal = reactive<{
 });
 
 onMounted(async () => {
+    // Detect an existing (un-cleared) session left behind by a previous login.
+    // This MUST run before any of the login-consuming branches below (ETL
+    // token, OIDC fragment, query-string token) - those branches call
+    // applySession()/persistSession(), which compares the newly-authenticated
+    // user against storedUsername to decide whether to wipe locally cached
+    // data from a different user. If this check ran after those branches
+    // instead, storedUsername would still be null at comparison time, so a
+    // browser previously used for one account could silently inherit that
+    // account's cached profile/WebSocket state when a different user logs in
+    // via SSO. The database is intentionally NOT deleted here - it is only
+    // cleared on an explicit sign-out or when a different user logs in via
+    // applySession()/destroySession(). This avoids a costly resync when a
+    // token simply expires.
+    try {
+        const existing = await appStore.getUsername();
+        if (existing) {
+            storedUsername.value = existing;
+            body.value.username = existing;
+        }
+    } catch (err) {
+        console.error('Failed to read existing session', err);
+    }
+
+    // Handle SSO login completion. The backend hands the session back via a
+    // URL Fragment (/login#sso=<base64url payload>) rather than a query
+    // string, so it is never sent to the server or written to access logs.
+    // Parse and clear the fragment immediately so it isn't left sitting in
+    // the address bar or browser history.
+    if (window.location.hash.startsWith('#sso=')) {
+        loading.value = true;
+        loadingMessage.value = 'Completing login...';
+        const payloadRaw = window.location.hash.slice('#sso='.length);
+        // Clear the fragment from the URL without triggering a navigation/reload.
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+        try {
+            const padded = payloadRaw + '='.repeat((4 - payloadRaw.length % 4) % 4);
+            const json = atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+            const payload = JSON.parse(json) as {
+                token: string;
+                email: string;
+                session: string;
+                redirect?: string;
+            };
+            await applySession({ token: payload.token, email: payload.email, session: payload.session });
+            emit('login');
+            const redirectPath = payload.redirect && payload.redirect.startsWith('/') ? payload.redirect : '/';
+            await router.replace(redirectPath);
+        } catch (err) {
+            loading.value = false;
+            console.error('Failed to parse SSO login payload', err);
+            // Fall through to normal login form
+        }
+        return;
+    }
+
     // Handle ETL API token passed as URL param for war room / kiosk display use.
     // These tokens start with 'etl.' and are exchanged for a session JWT via
     // POST /api/login/token before the normal login flow continues.
@@ -650,20 +705,6 @@ onMounted(async () => {
     // Only start conditional passkey autofill when ALB SSO is not active
     if (brandStore.passkey.enabled && !albOidcEnabled.value) {
         startConditionalPasskey();
-    }
-
-    // Detect an existing (un-cleared) session left behind by a previous login.
-    // The database is intentionally NOT deleted here - it is only cleared on an
-    // explicit sign-out or when a different user logs in. This avoids a costly
-    // resync when a token simply expires.
-    try {
-        const existing = await appStore.getUsername();
-        if (existing) {
-            storedUsername.value = existing;
-            body.value.username = existing;
-        }
-    } catch (err) {
-        console.error('Failed to read existing session', err);
     }
 });
 


### PR DESCRIPTION
### Summary

Fixes SSO login being completely broken since the in-app OIDC migration (#133) — every SSO login redirected back to `/login` with a valid session sitting in the URL, but nothing on the frontend ever read it, so no token was ever persisted. Every subsequent API request then failed with `401 No Auth Present`. Reported as: logged into Authentik at `account.demo.tak.nz`, but `map.demo.tak.nz` still showing "No Auth Present" on mobile.

### Root cause

The OIDC callback route (`api/routes/login.ts`) hands the session back to the browser via `/login#sso=<base64url payload>` — a URL **fragment**, chosen specifically so the session token never gets sent to the server or written to access logs/browser history.

`Login.vue` never actually gained the code to read that fragment. The original OIDC migration's commit message described adding a `consumeSSOLogin()` function for exactly this, but that code never made it into the actual committed diff — it was written during that session but lost via a `git checkout` used for an unrelated investigation, and the gap went unnoticed because the rest of that PR's tests don't cover the frontend fragment-consumption step.

### Changes

- `api/web/src/components/Login.vue`:
  - Added the `#sso=` fragment-parsing branch to the top of `onMounted()`, ahead of the existing ETL-token and query-string-token branches. It decodes the payload, clears the fragment via `history.replaceState()` immediately so it never lingers in the address bar or browser history, and hands off to the existing `applySession()` helper.
  - Moved the existing-session detection (`storedUsername`) to the very top of `onMounted()`, ahead of all login-consuming branches. It was previously running after them, which meant `applySession()`'s stale-profile-wipe check always saw `storedUsername` as `null` on a fresh SSO redirect — letting a browser previously used for one Authentik account silently inherit that account's cached profile/WebSocket state when a different user logged in via SSO on the same device.

### Testing

- `vue-tsc --noEmit` — clean.
- `vite build` — clean.
- Not yet verified against a live deployment — recommend deploying to Demo and confirming SSO login on both desktop and mobile before merging to be sure this specific regression is actually resolved.

### Priority

This is a live production-breaking bug for anyone using SSO login right now (post-#133) — recommend fast-tracking review/merge.