### PR TITLE
fix: dead OIDC settings code causing 401 on /login, connection indicator cross-tab flicker

### DIFF
--- a/api/web/src/base/events.ts
+++ b/api/web/src/base/events.ts
@@ -38,6 +38,12 @@ export enum WorkerMessageType {
 
 export type WorkerMessage = {
     type: WorkerMessageType,
+    // Identifies which browser tab's Atlas worker sent this message. The
+    // 'cloudtak' BroadcastChannel is shared by every tab from the same
+    // origin, so any listener that reflects per-tab connection state (see
+    // Connection_Open/Connection_Close in stores/map.ts) must check this
+    // against its own worker's tabId before acting on the message.
+    tabId?: string,
     // TODO Strongly type this
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     body?: any

--- a/api/web/src/components/Login.vue
+++ b/api/web/src/components/Login.vue
@@ -66,7 +66,7 @@
                                     v-if='loading'
                                     :desc='loadingMessage'
                                 />
-                                <template v-else-if='brandStore.oidc.enabled && brandStore.oidc.enforced'>
+                                <template v-else-if='albOidcEnabled && albOidcForced && !route.query.local'>
                                     <div class='text-center text-muted py-3'>
                                         <div class='mb-2'>
                                             <IconLock
@@ -145,39 +145,9 @@
                                         </button>
                                     </div>
                                 </template>
-                                <template v-if='brandStore.oidc.enabled'>
-                                    <div
-                                        v-if='!brandStore.oidc.enforced'
-                                        class='my-3 d-flex align-items-center'
-                                    >
-                                        <hr class='flex-grow-1 m-0'>
-                                        <span class='mx-2 text-muted small'>or</span>
-                                        <hr class='flex-grow-1 m-0'>
-                                    </div>
-                                    <TablerInlineAlert
-                                        v-if='!brandStore.oidc.discovery'
-                                        class='mb-2'
-                                        title='OIDC Misconfigured'
-                                        description='The administrator has not configured OIDC correctly. Please contact your system administrator.'
-                                        severity='warning'
-                                    />
-                                    <a
-                                        v-else
-                                        class='btn btn-secondary w-100 d-flex align-items-center justify-content-center gap-2'
-                                        href='/api/login/oidc'
-                                    >
-                                        <img
-                                            v-if='brandStore.oidc.logo'
-                                            :src='brandStore.oidc.logo'
-                                            style='height: 20px; width: 20px; object-fit: contain;'
-                                            alt=''
-                                        >
-                                        Sign in with {{ brandStore.oidc.name || 'SSO' }}
-                                    </a>
-                                </template>
                                 <template v-if='albOidcEnabled && !loading'>
                                     <div
-                                        v-if='!brandStore.oidc.enforced'
+                                        v-if='!albOidcForced || route.query.local'
                                         class='my-3 d-flex align-items-center'
                                     >
                                         <hr class='flex-grow-1 m-0'>
@@ -197,10 +167,7 @@
                                     </button>
                                 </template>
                                 <template v-if='brandStore.passkey.enabled && !loading && !albOidcEnabled'>
-                                    <div
-                                        v-if='!brandStore.oidc.enabled || !brandStore.oidc.enforced'
-                                        class='my-3 d-flex align-items-center'
-                                    >
+                                    <div class='my-3 d-flex align-items-center'>
                                         <hr class='flex-grow-1 m-0'>
                                         <span class='mx-2 text-muted small'>or</span>
                                         <hr class='flex-grow-1 m-0'>
@@ -411,26 +378,12 @@ const brandStore = reactive<{
     passkey: {
         enabled: boolean;
     };
-    oidc: {
-        enforced: boolean;
-        enabled: boolean;
-        discovery: string;
-        name: string;
-        logo: string;
-    };
 }>({
     loaded: false,
     login: undefined,
     passkey: {
         enabled: true,
     },
-    oidc: {
-        enforced: false,
-        enabled: false,
-        discovery: '',
-        name: '',
-        logo: ''
-    }
 });
 
 const footerLogoLoaded = ref(false);
@@ -625,11 +578,6 @@ onMounted(async () => {
         'login::brand::logo',
         'login::background::enabled',
         'login::background::color',
-        'oidc::enforced',
-        'oidc::enabled',
-        'oidc::discovery',
-        'oidc::name',
-        'oidc::logo',
         'passkey::enabled' as keyof FullConfig,
     ]);
 
@@ -648,15 +596,10 @@ onMounted(async () => {
             color: config['login::background::color']
         }
     };
-    brandStore.oidc.enforced = config['oidc::enforced'] === true;
-    brandStore.oidc.enabled = config['oidc::enabled'] === true;
-    brandStore.oidc.discovery = config['oidc::discovery'] as string || '';
-    brandStore.oidc.name = config['oidc::name'] as string || '';
-    brandStore.oidc.logo = config['oidc::logo'] as string || '';
     brandStore.passkey.enabled = (config as Record<string, unknown>)['passkey::enabled'] !== false;
     brandStore.loaded = true;
 
-    // Check ALB-based OIDC status (separate from Settings-driven generic OIDC)
+    // Check in-app OIDC status (env-var/CDK-driven, see GET /api/server/oidc)
     try {
         const oidcRes = await fetch('/api/server/oidc');
         if (oidcRes.ok) {

--- a/api/web/src/stores/map.ts
+++ b/api/web/src/stores/map.ts
@@ -112,6 +112,11 @@ export const useMapStore = defineStore('cloudtak', {
 
         timer: ReturnType<typeof setInterval> | null;
 
+        // This tab's own Atlas worker's tabId, cached after init() so the
+        // channel.onmessage handler can filter connection-status broadcasts
+        // without an async round-trip to the worker on every message.
+        _tabId?: string;
+
         _rawWorker?: Worker;
         _workerReady?: Promise<void>;
         _worker?: Comlink.Remote<Atlas>;
@@ -144,6 +149,7 @@ export const useMapStore = defineStore('cloudtak', {
         }
     } => {
         return {
+            _tabId: undefined,
             _rawWorker: undefined,
             _workerReady: undefined,
             _worker: undefined,
@@ -679,6 +685,7 @@ export const useMapStore = defineStore('cloudtak', {
 
             await this._workerReady!;
             await this.worker.init(token || '');
+            this._tabId = await this.worker.tabId;
 
             this.channel.onmessage = async (event: MessageEvent<WorkerMessage>) => {
                 const msg = event.data;
@@ -728,10 +735,18 @@ export const useMapStore = defineStore('cloudtak', {
                 } else if (msg.type === WorkerMessageType.Map_Projection) {
                     map.setProjection(msg.body);
                 } else if (msg.type === WorkerMessageType.Connection_Open) {
-                    this.isOpen = true;
+                    // The 'cloudtak' BroadcastChannel is shared by every tab
+                    // from the same origin - only reflect connection state
+                    // broadcast by THIS tab's own worker. Otherwise another
+                    // tab's connection dropping/reconnecting (e.g. a
+                    // backgrounded tab cycling through its reconnect
+                    // backoff) would flip this tab's indicator too, even
+                    // though this tab's own connection never changed.
+                    if (msg.tabId === this._tabId) this.isOpen = true;
                 } else if (msg.type === WorkerMessageType.Connection_Close) {
-                    this.isOpen = false;
+                    if (msg.tabId === this._tabId) this.isOpen = false;
                 } else if (msg.type === WorkerMessageType.Connection_AuthFailure) {
+                    if (msg.tabId !== this._tabId) return;
                     this.isOpen = false;
                     window.location.href = '/login';
                 } else if (msg.type === WorkerMessageType.Channels_None) {

--- a/api/web/src/workers/atlas.ts
+++ b/api/web/src/workers/atlas.ts
@@ -16,6 +16,15 @@ import Icon from '../base/icon.ts';
 export default class Atlas {
     channel: BroadcastChannel;
 
+    // Unique per-worker-instance (i.e. per browser tab/window) identifier.
+    // The 'cloudtak' BroadcastChannel is shared by every tab from the same
+    // origin, so connection status messages need this to let each tab's
+    // main-thread store (map.ts) tell "my worker's connection changed"
+    // apart from "some other tab's worker's connection changed" - without
+    // it, one backgrounded tab reconnecting/flapping would flip every other
+    // tab's connection indicator too.
+    tabId: string;
+
     token: string;
     username: string;
     initialized: boolean;
@@ -26,6 +35,7 @@ export default class Atlas {
 
     constructor() {
         this.channel = new BroadcastChannel('cloudtak');
+        this.tabId = self.crypto.randomUUID();
         this.token = '';
         this.username = '';
         this.initialized = false;
@@ -58,7 +68,7 @@ export default class Atlas {
     }
 
     async postMessage(msg: WorkerMessage): Promise<void> {
-        return this.channel.postMessage(msg);
+        return this.channel.postMessage({ ...msg, tabId: this.tabId });
     }
 
     async init(authToken: string) {


### PR DESCRIPTION
### Summary

Two unrelated frontend fixes:

1. Anonymous visits to `/login` (including the `?local=true` escape hatch) threw an uncaught 401 and never rendered a usable login form.
2. The "Return Home" button's connection status dot flickered red even when the current tab's connection was healthy.

### Fix 1: dead Settings-driven OIDC code causing 401 on `/login`

The earlier in-app OIDC migration (#133) removed the DB-Settings-driven generic OIDC backend (`types.ts`, `config.ts`'s `PublicConfigKeys`, `ConfigLogin.vue`'s admin UI) since our real OIDC config is entirely env-var/CDK-driven. That cleanup missed `Login.vue` itself, which still called `Config.list()` asking for `oidc::enforced`, `oidc::enabled`, `oidc::discovery`, `oidc::name`, and `oidc::logo` — keys that no longer exist anywhere in `FullConfig`/`PublicConfigKeys`. Since `GET /api/config` requires admin auth for any key it doesn't recognize as public, an anonymous visitor loading `/login` got an uncaught 401, aborting the rest of `onMounted()` before the passkey/SSO buttons ever rendered.

- Removed the dead `oidc::*` keys from the `Config.list()` call and the `brandStore.oidc` reactive sub-object entirely.
- The real, currently-wired-up in-app OIDC UI ("Login with SSO" button, "SSO only" banner, `?local=true` bypass separator) is driven by `albOidcEnabled`/`albOidcForced` from `GET /api/server/oidc` — untouched, just consolidated onto real state instead of the dead state sitting alongside it.

### Fix 2: connection status indicator cross-tab flicker

The Atlas Web Worker's `Connection_Open`/`Connection_Close` messages are broadcast on a single `BroadcastChannel('cloudtak')` shared by every tab/window from the same origin, with no identifier distinguishing which tab's worker sent a message. Any tab's WebSocket closing and reconnecting — background tabs get throttled and cycle through reconnect backoff far more than a foreground tab — flipped `isOpen` for every tab, including ones whose own connection never changed.

- `atlas.ts`: each worker instance gets a random `tabId` at construction; `postMessage()` stamps every outgoing message with it.
- `events.ts`: `WorkerMessage` gains an optional `tabId` field.
- `map.ts`: caches this tab's own `tabId` after `worker.init()`; the message handler only acts on connection-status messages whose `tabId` matches.

### Testing

- `vue-tsc --noEmit`, `tsc --noEmit` (api), `vite build` — all clean.
- `login-oidc.srv.test.ts` (15 tests) — passing.
- Fix 2 not yet verified against a live multi-tab session — recommend confirming on Demo with two tabs open (one backgrounded) before merging.