### PR TITLE
fix(login): remove dead Settings-driven OIDC code causing 401 on /login

### DIFF
--- a/api/web/src/components/Login.vue
+++ b/api/web/src/components/Login.vue
@@ -66,7 +66,7 @@
                                     v-if='loading'
                                     :desc='loadingMessage'
                                 />
-                                <template v-else-if='brandStore.oidc.enabled && brandStore.oidc.enforced'>
+                                <template v-else-if='albOidcEnabled && albOidcForced && !route.query.local'>
                                     <div class='text-center text-muted py-3'>
                                         <div class='mb-2'>
                                             <IconLock
@@ -145,39 +145,9 @@
                                         </button>
                                     </div>
                                 </template>
-                                <template v-if='brandStore.oidc.enabled'>
-                                    <div
-                                        v-if='!brandStore.oidc.enforced'
-                                        class='my-3 d-flex align-items-center'
-                                    >
-                                        <hr class='flex-grow-1 m-0'>
-                                        <span class='mx-2 text-muted small'>or</span>
-                                        <hr class='flex-grow-1 m-0'>
-                                    </div>
-                                    <TablerInlineAlert
-                                        v-if='!brandStore.oidc.discovery'
-                                        class='mb-2'
-                                        title='OIDC Misconfigured'
-                                        description='The administrator has not configured OIDC correctly. Please contact your system administrator.'
-                                        severity='warning'
-                                    />
-                                    <a
-                                        v-else
-                                        class='btn btn-secondary w-100 d-flex align-items-center justify-content-center gap-2'
-                                        href='/api/login/oidc'
-                                    >
-                                        <img
-                                            v-if='brandStore.oidc.logo'
-                                            :src='brandStore.oidc.logo'
-                                            style='height: 20px; width: 20px; object-fit: contain;'
-                                            alt=''
-                                        >
-                                        Sign in with {{ brandStore.oidc.name || 'SSO' }}
-                                    </a>
-                                </template>
                                 <template v-if='albOidcEnabled && !loading'>
                                     <div
-                                        v-if='!brandStore.oidc.enforced'
+                                        v-if='!albOidcForced || route.query.local'
                                         class='my-3 d-flex align-items-center'
                                     >
                                         <hr class='flex-grow-1 m-0'>
@@ -197,10 +167,7 @@
                                     </button>
                                 </template>
                                 <template v-if='brandStore.passkey.enabled && !loading && !albOidcEnabled'>
-                                    <div
-                                        v-if='!brandStore.oidc.enabled || !brandStore.oidc.enforced'
-                                        class='my-3 d-flex align-items-center'
-                                    >
+                                    <div class='my-3 d-flex align-items-center'>
                                         <hr class='flex-grow-1 m-0'>
                                         <span class='mx-2 text-muted small'>or</span>
                                         <hr class='flex-grow-1 m-0'>
@@ -411,26 +378,12 @@ const brandStore = reactive<{
     passkey: {
         enabled: boolean;
     };
-    oidc: {
-        enforced: boolean;
-        enabled: boolean;
-        discovery: string;
-        name: string;
-        logo: string;
-    };
 }>({
     loaded: false,
     login: undefined,
     passkey: {
         enabled: true,
     },
-    oidc: {
-        enforced: false,
-        enabled: false,
-        discovery: '',
-        name: '',
-        logo: ''
-    }
 });
 
 const footerLogoLoaded = ref(false);
@@ -625,11 +578,6 @@ onMounted(async () => {
         'login::brand::logo',
         'login::background::enabled',
         'login::background::color',
-        'oidc::enforced',
-        'oidc::enabled',
-        'oidc::discovery',
-        'oidc::name',
-        'oidc::logo',
         'passkey::enabled' as keyof FullConfig,
     ]);
 
@@ -648,15 +596,10 @@ onMounted(async () => {
             color: config['login::background::color']
         }
     };
-    brandStore.oidc.enforced = config['oidc::enforced'] === true;
-    brandStore.oidc.enabled = config['oidc::enabled'] === true;
-    brandStore.oidc.discovery = config['oidc::discovery'] as string || '';
-    brandStore.oidc.name = config['oidc::name'] as string || '';
-    brandStore.oidc.logo = config['oidc::logo'] as string || '';
     brandStore.passkey.enabled = (config as Record<string, unknown>)['passkey::enabled'] !== false;
     brandStore.loaded = true;
 
-    // Check ALB-based OIDC status (separate from Settings-driven generic OIDC)
+    // Check in-app OIDC status (env-var/CDK-driven, see GET /api/server/oidc)
     try {
         const oidcRes = await fetch('/api/server/oidc');
         if (oidcRes.ok) {


### PR DESCRIPTION
**Summary**

Fixes an uncaught 401 on page load of `/login` — most visibly the SSO auto-redirect not firing (falls through to a plain local login form/`?redirect=` param instead of redirecting to the IdP), even when OIDC is enabled and enforced.

**Root cause**

The earlier in-app OIDC migration (#133) removed the DB-Settings-driven generic OIDC backend (`types.ts`, `config.ts`'s `PublicConfigKeys`, `ConfigLogin.vue`'s admin UI) since our real OIDC config is entirely env-var/CDK-driven. That cleanup missed `Login.vue` itself, which still called `Config.list()` asking for `oidc::enforced`, `oidc::enabled`, `oidc::discovery`, `oidc::name`, and `oidc::logo` — keys that no longer exist anywhere in `FullConfig`/`PublicConfigKeys`. Since `GET /api/config` requires admin auth for any key it doesn't recognize as public, an anonymous visitor loading `/login` got an uncaught 401 from that call, aborting the rest of `onMounted()` before the code that checks `GET /api/server/oidc` and performs the SSO auto-redirect ever ran.

**Changes**

- Removed the dead `oidc::*` keys from the `Config.list()` call and the `brandStore.oidc` reactive sub-object entirely — it could never be populated (those keys don't exist) and was checked in five separate template conditions, several of which had become unreachable dead branches.
- The real, currently-wired-up in-app OIDC UI (the "Login with SSO" button, the "SSO only" banner, and the `?local=true` bypass separator) is driven by `albOidcEnabled`/`albOidcForced`, sourced from `GET /api/server/oidc` — untouched, just consolidated so the banner/separator conditions read from real state instead of the dead state that happened to sit alongside it.

**Testing**

- `vue-tsc --noEmit` and `vite build` — clean.
- `login-oidc.srv.test.ts` (15 tests) — passing.
- Manually confirmed on Demo that `GET /api/server/oidc` correctly returns `oidc_enabled: true, oidc_forced: true`, and that this was the code path silently failing to run before this fix.
