### PR TITLE
fix(login): suppress Welcome dialog on SSO first login + chore(cdk): upgrade CDK, double ECS task CPU

### DIFF
--- a/api/routes/login.ts
+++ b/api/routes/login.ts
@@ -10,6 +10,7 @@ import { UAParser } from 'ua-parser-js';
 import { X509Certificate } from 'crypto';
 import { discovery, authorizationUrl, exchangeCode, userinfo } from '../lib/oidc.js';
 import type { OIDCConfig } from '../lib/oidc.js';
+import { sql } from 'drizzle-orm';
 
 /** Returns true when the cert PEM is missing, unparseable, or expires within 7 days. */
 function certNeedsRenewal(certPem: string | undefined): boolean {
@@ -367,6 +368,19 @@ export default async function router(schema: Schema, config: Config) {
                             }
                             if (Object.keys(profileConfigUpdates).length > 0) {
                                 await config.models.ProfileConfig.commit(email, profileConfigUpdates);
+
+                                // The frontend (hasNoConfiguration() in atlas-profile.ts) and the
+                                // isFirstLogin check above both key off `profile.created ===
+                                // profile.updated` to decide whether the user still needs the
+                                // "Welcome" callsign/group/role wizard. Profile.commit() is a plain
+                                // SQL UPDATE that never touches `updated` unless it's explicitly
+                                // passed in the values - so without this, a successful Authentik
+                                // attribute sync above would populate the real callsign/group/role
+                                // but `updated` would stay pinned to `created` forever, and the
+                                // wizard would keep reappearing on every login despite the data
+                                // already being correct. Bumping `updated` here is what actually
+                                // suppresses the dialog once real values have been synced in.
+                                updates.updated = sql`Now()`;
                             }
                         }
                     } catch (err) {

--- a/api/test/login-oidc.srv.test.ts
+++ b/api/test/login-oidc.srv.test.ts
@@ -2,7 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert';
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
+import Sinon from 'sinon';
 import Flight from './flight.js';
+import AuthentikProvider from '../lib/authentik-provider.js';
 
 const flight = new Flight();
 
@@ -190,6 +192,74 @@ test('POST: api/login - allowed for system admin when OIDC_FORCED', async () => 
         });
     } catch (err) {
         assert.ifError(err);
+    }
+});
+
+test('GET: api/login/oidc/callback - Authentik attribute sync populates callsign/group/role and suppresses the Welcome dialog', async () => {
+    // Regression test for: new SSO users were shown the "Welcome" callsign/
+    // group/role dialog even when Authentik attribute sync had already
+    // populated real values, because the frontend (and the isFirstLogin
+    // check in login.ts) suppress that dialog based on `profile.created ===
+    // profile.updated`, and nothing in the sync path used to bump `updated`.
+    userinfoEmail = 'attributesync@example.com';
+    userinfoGroups = [];
+
+    process.env.AUTHENTIK_URL = 'http://authentik.invalid';
+    process.env.AUTHENTIK_API_TOKEN_SECRET_ARN = 'arn:aws:secretsmanager:fake:fake:secret:fake';
+
+    Sinon.stub(AuthentikProvider.prototype, 'auth').resolves({
+        expires: new Date(Date.now() + 60_000),
+        token: 'fake-authentik-token',
+    });
+
+    // enrollUserCertificate is exercised elsewhere (login.srv.test.ts /
+    // OIDC_FORCED tests above) via the real HTTP mock TAK server - stub it
+    // here purely so this test can focus on the attribute-sync/updated-bump
+    // behaviour without also having to mock the Authentik core API user
+    // lookup + password endpoints it depends on internally.
+    Sinon.stub(AuthentikProvider.prototype, 'enrollUserCertificate').resolves({
+        cert: '',
+        key: '',
+        ca: [],
+    });
+
+    Sinon.stub(AuthentikProvider.prototype, 'login').resolves({
+        id: 42,
+        name: 'Attribute Sync User',
+        phone: null,
+        system_admin: false,
+        agency_admin: [],
+        tak_callsign: 'ATTRSYNC (Web)',
+        tak_group: 'Blue',
+        tak_role: 'Team Lead',
+    });
+
+    try {
+        const location = await ssoLogin();
+        const payload = ssoPayload(location);
+        assert.equal(payload.email, 'attributesync@example.com');
+
+        const res = await fetch(`${flight.base}/api/profile`, {
+            headers: { Authorization: `Bearer ${payload.token}` },
+        });
+        const profile = await res.json();
+
+        assert.equal(profile.tak_callsign, 'ATTRSYNC (Web)');
+        assert.equal(profile.tak_group, 'Blue');
+        assert.equal(profile.tak_role, 'Team Lead');
+
+        // The core regression check: created !== updated once real Authentik
+        // attributes have been synced in, which is exactly what the frontend's
+        // hasNoConfiguration() and the backend's isFirstLogin check rely on to
+        // decide whether to show the "Welcome" dialog again.
+        assert.notEqual(
+            profile.updated, profile.created,
+            'Profile.updated must be bumped once Authentik attribute sync succeeds, otherwise the Welcome dialog keeps reappearing',
+        );
+    } finally {
+        Sinon.restore();
+        delete process.env.AUTHENTIK_URL;
+        delete process.env.AUTHENTIK_API_TOKEN_SECRET_ARN;
     }
 });
 

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -32,7 +32,7 @@
         "enableCloudWatchLogs": false
       },
       "ecs": {
-        "taskCpu": 1024,
+        "taskCpu": 2048,
         "taskMemory": 4096,
         "desiredCount": 1,
         "enableDetailedLogging": true,
@@ -82,7 +82,7 @@
         "enableCloudWatchLogs": false
       },
       "ecs": {
-        "taskCpu": 2048,
+        "taskCpu": 4096,
         "taskMemory": 8192,
         "desiredCount": 1,
         "enableDetailedLogging": false,

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,10 +8,10 @@
       "name": "@tak-nz/cloudtak-cdk",
       "version": "1.0.0",
       "dependencies": {
-        "@aws-cdk/cloud-assembly-schema": "^54.15.0",
-        "aws-cdk-lib": "2.263.0",
+        "@aws-cdk/cloud-assembly-schema": "^54.17.0",
+        "aws-cdk-lib": "2.264.0",
         "axios": "^1.12.0",
-        "constructs": "^10.8.0",
+        "constructs": "^10.8.1",
         "form-data": "^4.0.4",
         "source-map-support": "^0.5.21"
       },
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.14",
         "@types/node": "22.7.9",
-        "aws-cdk": "2.1135.0",
+        "aws-cdk": "2.1135.1",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -41,9 +41,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.16.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.16.0.tgz",
-      "integrity": "sha512-Mhwh/L1buy8r6ucxdjPqSAQB559pX1ehcfusRBpDrpoOi4vHKl/iWDjXz0p1QD6ySptlzCgqbBP8TE+EE6ew0w==",
+      "version": "54.17.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.17.0.tgz",
+      "integrity": "sha512-wV1GmMM5AvDkiJIenb9aJcBiGTa5KwX/C/mIjFZCsWsB5b1rEMLnwMageqrOpL2mWKicpxqS8ofF/Yte4Lm3Dg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -1265,9 +1265,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1135.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1135.0.tgz",
-      "integrity": "sha512-Vfz2kllheB+8y9audOtcw0qo0v6EnjxfO2pK7x6eSulHmD0GaAvkqrg6MF+20wxE2KTyuY1UDBzICO+nHUaFtA==",
+      "version": "2.1135.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1135.1.tgz",
+      "integrity": "sha512-g1jcMfWlyYtGamFJ/kPBOCuchl3NfwTF2UwOLTIDN0nJbGm84EAO+c8DlYnaemM8UmKFkdoq4BGdmiNL5nHWwA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1278,9 +1278,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.263.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
-      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
+      "version": "2.264.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.264.0.tgz",
+      "integrity": "sha512-TzeWc4aM2qftdoWzIgqV7DotzUO9+DqYLXHvL2qygZqkrJdvITTp8ojHstxYPH40FfA+RL4x5hVfa52NCTB0ZA==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -29,17 +29,17 @@
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
-    "aws-cdk": "2.1135.0",
+    "aws-cdk": "2.1135.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "~5.6.3"
   },
   "dependencies": {
-    "@aws-cdk/cloud-assembly-schema": "^54.15.0",
-    "aws-cdk-lib": "2.263.0",
+    "@aws-cdk/cloud-assembly-schema": "^54.17.0",
+    "aws-cdk-lib": "2.264.0",
     "axios": "^1.12.0",
-    "constructs": "^10.8.0",
+    "constructs": "^10.8.1",
     "form-data": "^4.0.4",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
### fix(login): suppress Welcome dialog once Authentik attributes sync

New SSO users were shown the "Welcome" callsign/group/role onboarding dialog even when Authentik had already supplied real values for callsign, group, and role — despite two prior fix attempts.

Root cause: both the frontend (`hasNoConfiguration()` in `atlas-profile.ts`) and the backend's `isFirstLogin` check key off `profile.created === profile.updated` to decide if the wizard is still needed. `Profile.commit()` is a plain SQL `UPDATE` that never touches `updated` unless explicitly passed — and nothing in the Authentik attribute-sync path in the OIDC callback ever did. So the sync could succeed and write the correct `tak::callsign`/`tak::group`/`tak::role` values, but the suppression signal stayed permanently stale, and the dialog kept reappearing on every login.

Fix: `api/routes/login.ts` now bumps `Profile.updated` via `sql\`Now()\`` whenever the Authentik attribute sync actually writes real values.

**Testing:**
- Added a regression test in `login-oidc.srv.test.ts` that stubs `AuthentikProvider` and asserts `profile.updated !== profile.created` after first-login sync.
- Confirmed the test fails without the fix and passes with it.
- Ran full `login-oidc`, `login`, `login-session`, `profile`, and `login-passkey` suites (50 tests) — all pass.
- `eslint` clean on changed files.

### chore(cdk): upgrade CDK and double ECS task CPU

- Upgrades CDK to the latest patch release: `aws-cdk` 2.1135.0 → 2.1135.1, `aws-cdk-lib` 2.263.0 → 2.264.0, `constructs` ^10.8.0 → ^10.8.1, `@aws-cdk/cloud-assembly-schema` ^54.15.0 → ^54.17.0.
- Doubles the CloudTAK ECS `taskCpu` in both environments: dev-test 1024 → 2048, prod 2048 → 4096. `taskMemory` left unchanged (4096 MiB dev-test, 8192 MiB prod) — both are valid Fargate CPU/memory pairs.

**Testing:**
- `npm run build` passes.
- All 16 CDK unit test suites (48 tests) pass under the upgraded CDK.

**Known issue (not introduced by this change):** `npm audit` flags a high-severity `brace-expansion` DoS advisory bundled inside `aws-cdk-lib`'s own `node_modules`. Not fixable from our `package.json` — requires an upstream `aws-cdk-lib` release.