### PR TITLE
chore: add a local data/ area for large geospatial archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,13 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Large geospatial source archives kept locally for convenience. These are
+# published datasets, not fork content - see data/README.md for provenance and
+# how to re-fetch. Also excluded from the root-context Docker image assets in
+# cdk/lib/cloudtak-stack.ts, or a local `cdk synth` would stage them into
+# cdk.out and hand them to the Docker daemon on every run.
+data/*.pmtiles
+data/*.mbtiles
+data/*.tif
+data/*.laz

--- a/cdk/lib/cloudtak-stack.ts
+++ b/cdk/lib/cloudtak-stack.ts
@@ -202,6 +202,12 @@ export class CloudTakStack extends cdk.Stack {
           // change under branding/ rewrites their asset hash and forces a
           // pointless rebuild and ECR push of images that never read it.
           'branding/**',
+          // Large published geospatial archives kept locally for convenience
+          // (see data/README.md). Same reasoning as branding/, but the stakes
+          // are higher: a single .pmtiles here is over a gigabyte, so including
+          // it would stage that into cdk.out and hand it to the Docker daemon on
+          // every local synth.
+          'data/**',
         ]
       });
       
@@ -231,6 +237,12 @@ export class CloudTakStack extends cdk.Stack {
           // change under branding/ rewrites their asset hash and forces a
           // pointless rebuild and ECR push of images that never read it.
           'branding/**',
+          // Large published geospatial archives kept locally for convenience
+          // (see data/README.md). Same reasoning as branding/, but the stakes
+          // are higher: a single .pmtiles here is over a gigabyte, so including
+          // it would stage that into cdk.out and hand it to the Docker daemon on
+          // every local synth.
+          'data/**',
         ]
       });
 
@@ -260,6 +272,12 @@ export class CloudTakStack extends cdk.Stack {
           // change under branding/ rewrites their asset hash and forces a
           // pointless rebuild and ECR push of images that never read it.
           'branding/**',
+          // Large published geospatial archives kept locally for convenience
+          // (see data/README.md). Same reasoning as branding/, but the stakes
+          // are higher: a single .pmtiles here is over a gigabyte, so including
+          // it would stage that into cdk.out and hand it to the Docker daemon on
+          // every local synth.
+          'data/**',
         ]
       });
       

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,93 @@
+# `data/`
+
+Large published geospatial archives, kept locally so they don't have to be
+re-fetched. **The archives themselves are not tracked in git** — `.gitignore`
+excludes `*.pmtiles`, `*.mbtiles`, `*.tif` and `*.laz` here. This file records
+what belongs in the directory, where it came from, and how to reproduce it.
+
+`data/**` is also excluded from the three root-context `DockerImageAsset`s in
+[`cdk/lib/cloudtak-stack.ts`](../cdk/lib/cloudtak-stack.ts). Those build from the
+repository root, so without the exclusion a multi-gigabyte archive would be
+staged into `cdk.out` and handed to the Docker daemon on every local `cdk synth`.
+
+---
+
+## `nz-building-heights.pmtiles`
+
+Above-ground height for every building in New Zealand, for 3D building
+extrusion (MapLibre `fill-extrusion`).
+
+| | |
+|---|---|
+| Dataset | Aotearoa New Zealand Building Heights |
+| Author | Atman Dhruva |
+| Home | <https://heights.anicca.nz/> |
+| **Licence** | **CC BY 4.0** — <https://creativecommons.org/licenses/by/4.0/> |
+| Derived from | LINZ open LiDAR elevation data |
+| Source URL | `https://tiles.anicca.nz/buildings-20260810T1048.pmtiles` |
+| Size | 1,143,287,793 bytes |
+| Origin ETag | `7315d8dfbefd1259291752e3fc97120b-219` |
+
+### Attribution is required
+
+CC BY 4.0 obliges us to credit both the dataset author and LINZ wherever this is
+displayed. Set the basemap/overlay `attribution` field to something like:
+
+> Building heights © Atman Dhruva, CC BY 4.0. Derived from LINZ LiDAR, CC BY 4.0.
+
+### Method (the author's, summarised)
+
+Roof 90th percentile minus ground under the LINZ building outline. The 90th
+percentile rather than the maximum is what rejects chimneys, aerials and
+overhanging tree canopy.
+
+### Contents
+
+Read from the archive itself, not from the website:
+
+- PMTiles v3, MVT tiles, gzip compressed
+- Zoom **4–16** (MapLibre overzooms above 16)
+- Bounds `167.3900,-46.9090 → 178.5482,-34.4260`
+- 347,418 tiles; **3,172,034** building polygons
+- **source-layer: `buildings`**
+- Built with `tippecanoe v2.80.0 -Z4 -z16 --drop-densest-as-needed
+  --extend-zooms-if-still-dropping -M 1500000 -l buildings`
+
+19 attributes: `building_id`, `height_m`, `height_block_m`, `height_max_m`,
+`roof_p50`, `roof_p70`, `roof_p90`, `roof_max`, `ground_m`, `n_pixels`,
+`ndvi_applied`, `canopy_fixed`, `flagged`, `peak_unverified`, `post_survey`,
+`imagery_year`, `imagery_end`, `lidar_year`, `lidar_end`.
+
+`height_m` is the one to extrude by. Because `--drop-densest-as-needed` thins
+buildings heavily below zoom 9, a style should set `minzoom` around 15 or the
+lower zooms show a misleading subset.
+
+### Re-fetching
+
+A single unbroken GET of the whole file is refused by the origin's Cloudflare bot
+protection. Ranged requests — the format's native access pattern — pass without
+issue. `scripts/fetch-nz-building-heights.py` does this in 5 MiB chunks aligned
+to the origin's S3 multipart layout, which lets it recompute the composite ETag
+and prove the copy is byte-identical rather than merely the right length.
+
+```bash
+python3 scripts/fetch-nz-building-heights.py
+```
+
+Observed throughput is roughly 8.6 MB/s, so about two and a half minutes.
+
+### Hosting
+
+Uploaded to `s3://<assets-bucket>/public/nz-building-heights.pmtiles`, which is
+the prefix CloudTAK's own PMTiles service lists and opens
+(`tasks/pmtiles/src/routes/public.ts`).
+
+Note that `tiles.test.tak.nz` is **TileServer GL**, not that service — it serves
+`/data/<id>/{z}/{x}/{y}` and reads from its own configuration, so publishing
+there is a separate step on that host.
+
+### Refresh
+
+The source filename is timestamped (`buildings-20260810T1048`), so new releases
+land at new URLs. Check <https://heights.anicca.nz/> for the current one and
+update the constants in the fetch script.

--- a/scripts/fetch-nz-building-heights.py
+++ b/scripts/fetch-nz-building-heights.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Range-fetch the NZ Building Heights PMTiles archive.
+
+Chunked deliberately: a single unbroken 1.14 GB GET trips Cloudflare's bot
+rules, while ranged requests are the archive format's native access pattern and
+pass fine. Chunk size matches the origin's S3 multipart part size (5 MiB, which
+the "...-219" ETag suffix implies for this object length), so the composite
+ETag can be recomputed at the end to prove the copy is byte-identical.
+"""
+import hashlib
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+URL = "https://tiles.anicca.nz/buildings-20260810T1048.pmtiles"
+OUT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "data", "nz-building-heights.pmtiles")
+TOTAL = 1_143_287_793
+PART = 5 * 1024 * 1024           # 5 MiB, matches the origin's multipart layout
+EXPECT_ETAG = "7315d8dfbefd1259291752e3fc97120b-219"
+UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36"
+
+nparts = (TOTAL + PART - 1) // PART
+
+
+def fetch(start, end, attempts=5):
+    """GET a single byte range, with backoff. Returns bytes."""
+    last = None
+    for a in range(attempts):
+        try:
+            req = urllib.request.Request(URL, headers={
+                "Range": f"bytes={start}-{end}",
+                "User-Agent": UA,
+                "Accept": "*/*",
+            })
+            with urllib.request.urlopen(req, timeout=120) as r:
+                if r.status != 206:
+                    raise RuntimeError(f"expected 206, got {r.status}")
+                buf = r.read()
+            want = end - start + 1
+            if len(buf) != want:
+                raise RuntimeError(f"short read: {len(buf)} != {want}")
+            return buf
+        except Exception as e:                      # noqa: BLE001 - retry anything
+            last = e
+            time.sleep(2 ** a)
+    raise RuntimeError(f"range {start}-{end} failed after {attempts}: {last}")
+
+
+def main():
+    resume = os.path.exists(OUT) and os.path.getsize(OUT) % PART == 0
+    done = os.path.getsize(OUT) if resume else 0
+    first = done // PART
+    if first:
+        print(f"resuming at part {first}/{nparts}", flush=True)
+
+    md5s = []
+    if first:
+        # Re-hash what we already have so the ETag check stays valid.
+        with open(OUT, "rb") as fh:
+            for _ in range(first):
+                md5s.append(hashlib.md5(fh.read(PART)).digest())
+
+    t0 = time.time()
+    with open(OUT, "ab" if first else "wb") as fh:
+        for i in range(first, nparts):
+            start = i * PART
+            end = min(start + PART, TOTAL) - 1
+            buf = fetch(start, end)
+            fh.write(buf)
+            md5s.append(hashlib.md5(buf).digest())
+            if (i + 1) % 20 == 0 or i + 1 == nparts:
+                mb = (end + 1) / 1e6
+                rate = mb / max(time.time() - t0, 0.001)
+                pct = 100 * (end + 1) / TOTAL
+                print(f"  part {i+1:>3}/{nparts}  {mb:>8.1f} MB  {pct:5.1f}%  {rate:5.1f} MB/s", flush=True)
+
+    size = os.path.getsize(OUT)
+    etag = hashlib.md5(b"".join(md5s)).hexdigest() + f"-{len(md5s)}"
+
+    print(f"\nsize      : {size:,} (expected {TOTAL:,}) {'OK' if size == TOTAL else 'MISMATCH'}")
+    with open(OUT, "rb") as fh:
+        magic = fh.read(7)
+    print(f"magic     : {magic!r} {'OK' if magic == b'PMTiles' else 'MISMATCH'}")
+    print(f"etag      : {etag}")
+    print(f"expected  : {EXPECT_ETAG} {'OK' if etag == EXPECT_ETAG else 'MISMATCH'}")
+
+    ok = size == TOTAL and magic == b"PMTiles" and etag == EXPECT_ETAG
+    print("\nRESULT: " + ("byte-identical to origin" if ok else "VERIFICATION FAILED"))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a `data/` directory for large **published** geospatial archives that we want on
disk but not in the repo. First occupant is the CC BY 4.0 "Aotearoa NZ Building
Heights" PMTiles archive (1.14 GB), used for 3D building extrusion.

No archive is tracked by this PR — only the ignore rules, the build-context
exclusions, provenance docs, and a fetch script. Largest file added is 3.7 KB.

## Why the CDK change is the important part

`cdk/lib/cloudtak-stack.ts` builds three `DockerImageAsset`s from the repository
root. Without an exclusion, a single 1.14 GB file in `data/` gets staged into
`cdk.out` and handed to the Docker daemon on **every local synth**, which would
quietly undo the synth speedup from #142 (~190s → ~16s). `data/**` is excluded
in all three, matching the existing `branding/**` exclusion and reasoning.

## Changes

- **`.gitignore`** — exclude `data/*.{pmtiles,mbtiles,tif,laz}`
- **`cdk/lib/cloudtak-stack.ts`** — exclude `data/**` from the three
  root-context `DockerImageAsset`s (3 × 6 lines, comment + entry)
- **`data/README.md`** — provenance, licence, attribution wording, archive
  contents (zoom 4–16, 3,172,034 polygons, `source-layer: buildings`, the 19
  attributes and which one to extrude by), and re-fetch instructions
- **`scripts/fetch-nz-building-heights.py`** — resumable ranged download

## Why the fetch script exists

A single unbroken GET of the archive is refused by the origin's Cloudflare bot
protection (it returns a 4,569-byte challenge page). Ranged requests — the
PMTiles format's native access pattern — pass fine. The script chunks at 5 MiB
to match the origin's S3 multipart layout, so it can recompute the composite
ETag and prove the copy is *byte-identical* rather than merely the right length.
It resumes from a partial file and exits non-zero on any verification failure.

## Verification

- Fetch script run end to end: 1,143,287,793 bytes, magic `PMTiles`, recomputed
  ETag `7315d8dfbefd1259291752e3fc97120b-219` — matches origin, byte-identical
- Archive confirmed absent from the commit; `git check-ignore` resolves it to
  `.gitignore:159`
- CDK exclusion exercised in practice — the archive has been sitting in `data/`
  through repeated local synths with no re-staging and no regression from ~16s

## Notes for review

- **Attribution is a licence obligation.** CC BY 4.0 requires crediting both the
  dataset author and LINZ wherever this renders. The wording to use is in
  `data/README.md`; it's already set on the test-environment overlay.
- The source filename is timestamped (`buildings-20260810T1048`), so refreshes
  land at new URLs and the script's constants need updating. Documented.
- `scripts/**` is not in `demo-deploy.yml`'s `paths-ignore`, so merging this
  triggers a no-op demo deployment.
